### PR TITLE
 Ensure "Take the Test" button is always enabled

### DIFF
--- a/app/assets/javascripts/home.coffee
+++ b/app/assets/javascripts/home.coffee
@@ -120,6 +120,7 @@ document.addEventListener('turbolinks:load', ->
   numeric_field_constraint()
 
   if window.location.pathname == '/'
+    get_location()
     start_speed_test()
     set_error_for_invalid_fields()
 
@@ -128,7 +129,6 @@ document.addEventListener('turbolinks:load', ->
   $('.test-speed-btn').prop('disabled', true)
 
   $('#take_test').on 'click', ->
-    get_location()
     $('.title-container').addClass('hidden');
     $('#form-container').removeClass('hide')
     $('#form-step-1 input').prop('disabled', false)

--- a/app/assets/javascripts/home.coffee
+++ b/app/assets/javascripts/home.coffee
@@ -30,8 +30,6 @@ set_coords = (position) ->
         $("input[name='submission[zip_code]']").attr 'value', data['zip_code']
         $('.test-speed-btn').prop('disabled', false)
         $('.location-warning').addClass('hide')
-        $('#take_test').prop('disabled', false)
-        $('#take_test').addClass('opacity-100')
         $.getJSON 'https://jsonip.com/?callback=?', (result_data) ->
           $('#submission_ip_address').val result_data.ip.split(',')[0]
 
@@ -108,13 +106,20 @@ set_error_for_invalid_fields = ->
       $('#submission_provider_down_speed').removeClass('got-error')
       $('#speed_error_span').addClass('hide')
 
-$ ->
+###
+# Turbolinks handles our navigation so that the page is updated dynamically; so
+# DOMContentLoaded is only fired when the site is first visited.  Below, we're
+# using an event which Turbolinks fires each time it emulates a page load.
+# This allows us to emulate the behavior of DOMContentLoaded.
+#
+# https://github.com/turbolinks/turbolinks#observing-navigation-events
+###
+document.addEventListener('turbolinks:load', ->
   bind_rating_stars()
   disable_form_inputs()
   numeric_field_constraint()
 
   if window.location.pathname == '/'
-    get_location()
     start_speed_test()
     set_error_for_invalid_fields()
 
@@ -123,6 +128,7 @@ $ ->
   $('.test-speed-btn').prop('disabled', true)
 
   $('#take_test').on 'click', ->
+    get_location()
     $('.title-container').addClass('hidden');
     $('#form-container').removeClass('hide')
     $('#form-step-1 input').prop('disabled', false)
@@ -141,3 +147,4 @@ $ ->
     $(testing_for + ' input').prop('disabled', false)
     $(testing_for + ' select').prop('disabled', false)
     $('#form-step-1').addClass('hide')
+)

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -318,7 +318,6 @@ body.in-stats .background-container,
 #take_test {
   background: none;
   border: none;
-  opacity: 0.5;
   width: 60%;
 }
 

--- a/app/views/home/_introduction.html.erb
+++ b/app/views/home/_introduction.html.erb
@@ -6,7 +6,7 @@
   <div class='options-container'>
     <ul class='list-inline'>
       <li>
-        <%= button_tag type: 'button', disabled: true, id: 'take_test' do %>
+        <%= button_tag type: 'button', id: 'take_test' do %>
           <%= image_tag 'take_the_test.png', class: 'take-test-img' %>
         <% end %>
           <p>Take the Test!!</p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,6 @@
 
     <div class='collapse navbar-collapse' id='bs-example-navbar-collapse-1'>
       <ul class='nav navbar-nav navbar-right header-links'>
-        <li><%= link_to 'Take the Test', root_path, data: { no_turbolink: true } %></li>
         <li><%= link_to 'View Map', result_page_path, data: { no_turbolink: true } %></li>
       </ul>
     </div>


### PR DESCRIPTION
Previously, this button was disabled by default and then only enabled on the first page load (not when navigating home through the site).  Even on that load it was only enabled after an XHR call to an endpoint on our server to retrieve location information.

This commit fixes this with the following changes:

* The button is enabled by default and still works when navigating back.
* The location information is retrieved when the button is clicked rather than immediately on load.
* Remove "Take the Test" link from the header. This link didn't function previously.  It would have been fairly simple to fix it on the home page, but seems that it would take a larger rework for it to function when clicked from other pages.  For now, we can remove this broken functionality, though we *will* later want to point users toward the test from every page.

Related issues: #19 #20 #28 