### PR TITLE
Added FaceBook Sharing Link

### DIFF
--- a/app/views/shared/_social_sharing_links.html.erb
+++ b/app/views/shared/_social_sharing_links.html.erb
@@ -1,6 +1,8 @@
 <div class='social-sharing-links'>
   <span class='speeduplou'>#SpeedUpAmerica </span>
-  <span class='social-share-btn' data-share='facebook-img'><%= image_tag 'facebook.png', width: 21 %> Share on Facebook</span>
+  <%= link_to "https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.facebook.com%2FSpeed-Up-America-416927695803950%2F", class:'social-share-btn', target: '_blank' do %>
+    <%= image_tag 'facebook.png', width: 21 %> Share on Facebook
+  <% end %>
   <%= link_to "https://twitter.com/share?text=I just tested my internet speed with Speed Up America! Check it out here:&url=#{request.url}&hashtags=speedupamerica", class: 'social-share-btn', target: '_blank' do %>
     <%= image_tag 'twitter.png', width: 21 %> Share on Twitter
   <% end %>


### PR DESCRIPTION
Link option was not present and this now uses the FaceBook page that Matt shared with us