### PR TITLE
Don't set coord fields from ndt_speed_test.coffee

### DIFF
--- a/app/assets/javascripts/ndt_speed_test.coffee
+++ b/app/assets/javascripts/ndt_speed_test.coffee
@@ -6,8 +6,6 @@ bind_ndt_speed_calculation = ->
   ndtUpdateInterval = 1000
 
   success = (position) ->
-    document.getElementById('submission_latitude').value = position.coords.latitude
-    document.getElementById('submission_longitude').value = position.coords.longitude
     xhr = new XMLHttpRequest
     currentLocationURL = 'https://nominatim.openstreetmap.org/reverse?format=json&lat=' + position.coords.latitude + '&lon=' + position.coords.longitude + '&zoom=18&addressdetails=1'
     xhr.open 'GET', currentLocationURL, true


### PR DESCRIPTION
The form fields with IDs `submission_latitude` and `submission_longitude` are already set from `set_coords()` in home.coffee, which is also responsible for enabling the button that starts the speed test. We don't need to duplicate this functionality; the call chain for both of these async functions even begin at the same point in home.coffee.