### PR TITLE
Draw polygons on the map when results page loads

### DIFF
--- a/app/assets/javascripts/mapbox.coffee
+++ b/app/assets/javascripts/mapbox.coffee
@@ -406,9 +406,7 @@ set_multiple_selected_values = ->
     $("#selected_#{id}").val($("##{id}").val())
 
 apply_filters = (map) ->
-  $('#map-filters .filter').on 'change', ->
-    set_date_filters_value($(this)) if $(this).val() == ''
-    update_all_option($(this))
+  update_map = ->
     provider = $('#provider').val()
     group_by = $('#group_by').val()
     test_type = $('#test_type').val()
@@ -427,6 +425,13 @@ apply_filters = (map) ->
       set_mapbox_gl_data(map, provider, date_range, group_by, test_type)
     else if group_by == 'all_responses' && isIE()
       set_mapbox_markers_data(map, provider, date_range, group_by, test_type)
+
+  $('#map-filters .filter').on 'change', ->
+    set_date_filters_value($(this)) if $(this).val() == ''
+    update_all_option($(this))
+    update_map()
+
+  update_map()
 
 get_stats_filters = ->
   {
@@ -493,13 +498,21 @@ bind_datetimepicker = ->
 
 $(document).ready ->
   if window.location.pathname.indexOf('result') >= 0 || window.location.pathname.indexOf('embed') >= 0
+
+    # Create maps
     all_results_map = initialize_mapbox('all_results_map')
     zip_code_map = initialize_mapbox('zip_code_map')
-    apply_submission_filters()
-    apply_filters(all_results_map)
+
+    # Initialize filter values
     bind_chosen_select()
-    bind_datetimepicker()
     set_multiple_selected_values()
+
+    # Draw polygons on the map
+    apply_filters(all_results_map)
+
+    # Add functionality to UI
+    apply_submission_filters()
+    bind_datetimepicker()
 
     $.loadScript 'https://code.highcharts.com/highcharts.js', ->
       apply_stats_filters(zip_code_map)

--- a/app/assets/javascripts/mapbox.coffee
+++ b/app/assets/javascripts/mapbox.coffee
@@ -42,7 +42,6 @@ initialize_mapbox = (map) ->
   map
 
 set_mapbox_polygon_data = (map, provider, date_range, group_by='zip_code', test_type='download') ->
-  $('#loader').removeClass('hide')
   $.ajax
     url: '/mapbox_data'
     type: 'POST'
@@ -78,7 +77,6 @@ set_mapbox_polygon_data = (map, provider, date_range, group_by='zip_code', test_
       disable_filters('map-filters', false)
 
 set_mapbox_census_data = (map, provider, date_range, test_type, zip_code, census_code, type) ->
-  $('#loader').removeClass('hide')
   $.ajax
     url: '/mapbox_data'
     type: 'POST'
@@ -118,7 +116,6 @@ set_mapbox_census_data = (map, provider, date_range, test_type, zip_code, census
 set_mapbox_markers_data = (map, provider, date_range, group_by='all_responses', test_type='download') ->
   $('#mapbox_gl_map').addClass('hide')
   $('#all_results_map').removeClass('hide')
-  $('#loader').removeClass('hide')
   $.ajax
     url: '/mapbox_data'
     type: 'POST'
@@ -160,7 +157,6 @@ set_mapbox_gl_data = (map, provider, date_range, group_by='all_responses', test_
   $('#mapbox_gl_map').removeClass('hide')
   $('#all_results_map').addClass('hide')
 
-  $('#loader').removeClass('hide')
   $.ajax
     url: '/mapbox_data'
     type: 'POST'


### PR DESCRIPTION
Previously, data was only drawn on the map when a filter setting was changed. Now, the relevant function is called right away, in addition to being added to a 'change' listener.

I've also adjusted the handling of the map spinner so that it is only shown as the map is first loading. It is no longer shown when changing filters (e.g. Zip Code -> Census Tract). There *is* a delay while the new data is being fetched before the new polygons are drawn, but it feels less "slow" to me from a UX standpoint. That delay could be affected by many things, though, such as connection speed, size of data, and server load, so it's a tradeoff. On the other hand, without this change, the map wouldn't be visible at *all* during that time. This change was made in a separate commit, so it's easy to remove if there's disagreement on it being an improvement (just let me know and I'll update the PR).

Closes #54 