### PR TITLE
Add logos for TAO and US Ignite to results page

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -60,6 +60,7 @@ body.result-page {
 .bold {
   font-weight: bold
 }
+
 .options-container a {
   color: #546e7a;
 }
@@ -111,7 +112,6 @@ body.result-page {
 
 .checkbox label::after {
   top: -5px;
-
 }
 
 .checkbox label::before {
@@ -120,7 +120,10 @@ body.result-page {
   margin-left: -21px
 }
 
-.radio input[type="radio"], .radio-inline input[type="radio"], .checkbox input[type="checkbox"], .checkbox-inline input[type="checkbox"] {
+.radio input[type="radio"],
+.radio-inline input[type="radio"],
+.checkbox input[type="checkbox"],
+.checkbox-inline input[type="checkbox"] {
   margin-left: -15px
 }
 
@@ -149,7 +152,7 @@ body.result-page {
 
 body.in-stats .background-container,
 .background-container  {
-  background-color: rgba(0,0,0,0.7);
+  background-color: rgba(0, 0, 0, 0.7);
   height: 100%;
   width: 100%;
   display: inline-block;
@@ -170,7 +173,9 @@ body.in-stats .background-container,
   width: 100%;
 }
 
-.social-share-button-twitter, .social-share-button-facebook, .social-share-button-linkedin {
+.social-share-button-twitter,
+.social-share-button-facebook,
+.social-share-button-linkedin {
   background: none;
   width: 50px;
   height: 50px;
@@ -200,7 +205,7 @@ body.in-stats .background-container,
 }
 
 #introduction {
-  >p{
+  >p {
     margin: 20px 20px 0;
     font-size: 16px;
     line-height: 28px;
@@ -212,13 +217,13 @@ body.in-stats .background-container,
     margin-left: 0;
     margin-top: 15px;
   }
-    li {
-      width: 40%;
+  li {
+    width: 40%;
 
-      img {
-        max-width: 100%
-      }
+    img {
+      max-width: 100%
     }
+  }
 }
 
 .resultTable {
@@ -251,33 +256,38 @@ body.in-stats .background-container,
   padding-bottom: 10px
 }
 
-.primaryBtn, .test-speed-btn {
+.primaryBtn,
+.test-speed-btn {
   background: #efefef;
   background: -moz-linear-gradient(top, #efefef 0%, #d2d2d2 100%);
   background: -webkit-linear-gradient(top, #efefef 0%,#d2d2d2 100%);
-  background: linear-gradient(to bottom, #efefef 0%,#d2d2d2 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#efefef', endColorstr='#d2d2d2',GradientType=0 );
+  background: linear-gradient(to bottom, #efefef 0%, #d2d2d2 100%);
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#efefef', endColorstr='#d2d2d2', GradientType=0);
   border: 1px solid #ababab;
   color: #000;
   padding: 8px 15px;
   border-radius: 5px;
   transition: all 0.5s ease;
+
   &:hover {
     background: #d2d2d2;
     background: -moz-linear-gradient(top, #d2d2d2 0%, #efefef 100%);
-    background: -webkit-linear-gradient(top, #d2d2d2 0%,#efefef 100%);
-    background: linear-gradient(to bottom, #d2d2d2 0%,#efefef 100%);
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#d2d2d2', endColorstr='#efefef',GradientType=0 );
+    background: -webkit-linear-gradient(top, #d2d2d2 0%, #efefef 100%);
+    background: linear-gradient(to bottom, #d2d2d2 0%, #efefef 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#d2d2d2', endColorstr='#efefef', GradientType=0);
   }
 }
+
 .rating-container .filled-stars {
   color: #30b2a8;
   text-shadow: 1px 1px #30b2a8
 }
+
 .rating-container {
   .glyphicon-star-empty:before {
   }
 }
+
 .rating-container .filled-stars {
   .glyphicon-star:before {
     color: #30b2a8;
@@ -296,12 +306,14 @@ body.in-stats .background-container,
     }
   }
 }
+
 .form-control:focus {
   border-color: #1b9087 !important;
   box-shadow: none !important;
 }
 
-.checkbox input[type="checkbox"]:focus + label::before, .checkbox input[type="radio"]:focus + label::before {
+.checkbox input[type="checkbox"]:focus + label::before,
+.checkbox input[type="radio"]:focus + label::before {
   outline: none;
 }
 
@@ -343,13 +355,13 @@ body.in-stats .background-container,
 }
 
 .navbar-brand {
-&.color-white {
-  span {
-    margin-left: 5px;
-    vertical-align: sub;
-    font-weight: 300
+  &.color-white {
+    span {
+      margin-left: 5px;
+      vertical-align: sub;
+      font-weight: 300
+    }
   }
-}
 }
 
 .progress-list {
@@ -380,22 +392,23 @@ body.in-stats .background-container,
 .negative-margin-left-20 {
   margin-left: -20px;
 }
+
 .partnerLogos {
   a {
     img {
-    display: inline-block;
-    margin-right: 2%;
+      display: inline-block;
+      margin-right: 2%;
     }
-  &:first-child img{
+    &:first-child img {
       width: 14%;
     }
-    &:nth-child(2) img{
+    &:nth-child(2) img {
       width: 15%;
     }
-    &:nth-child(3) img{
+    &:nth-child(3) img {
       width: 25%;
     }
-    &:last-child img{
+    &:last-child img {
       width: 30%;
       margin-right: 0;
     }
@@ -405,22 +418,25 @@ body.in-stats .background-container,
     margin-bottom: 0
   }
   ul {
-  padding: 0 5%;
-  li {
-    width: 23% !important;
-    display: inline-block;
-    list-style: none;
-    a {
-      margin-right: 20px;
+    padding: 0 5%;
+
+    li {
+      width: 23% !important;
       display: inline-block;
-      vertical-align: middle;
-     img {
-      max-width: 100%;
+      list-style: none;
+
+      a {
+        margin-right: 20px;
+        display: inline-block;
+        vertical-align: middle;
+
+        img {
+          max-width: 100%;
+        }
       }
-    }
-   &:last-child a {
-      margin-right: 0
-    }
+      &:last-child a {
+        margin-right: 0
+      }
     }
   }
 }
@@ -464,8 +480,14 @@ body.in-stats .background-container,
   }
 }
 
-.social-share-btn:hover, .social-share-btn:link, .social-share-btn:visited, .social-share-btn:active,
-.social-share-btn a:hover, .social-share-btn a:link, .social-share-btn a:visited, .social-share-btn a:active {
+.social-share-btn:hover,
+.social-share-btn:link,
+.social-share-btn:visited,
+.social-share-btn:active,
+.social-share-btn a:hover,
+.social-share-btn a:link,
+.social-share-btn a:visited,
+.social-share-btn a:active {
   color: white;
   text-decoration: none;
   cursor: pointer;
@@ -642,6 +664,7 @@ body.in-stats .background-container,
 body.in-stats {
   background: #f9f9f9;
 }
+
 body.in-stats .title-container {
   margin-bottom: 0;
 }
@@ -666,7 +689,7 @@ body.in-stats h2 {
 
 .white-section {
   background: white;
-  box-shadow: 0 0 5px 0 rgb( 226, 226, 226 );
+  box-shadow: 0 0 5px 0 rgb(226, 226, 226);
   margin-bottom: 65px;
   padding-bottom: 60px;
 }
@@ -687,7 +710,7 @@ body.in-stats h2 {
 }
 
 .improve-btn {
-  background: rgb( 10, 189, 158 );
+  background: rgb(10, 189, 158);
   padding: 10px 20px;
   font-size: 20px;
   text-align: center;
@@ -727,6 +750,7 @@ body.in-stats h2 {
   text-align: center;
   color: #3b3535;
 }
+
 .speed-participation {
   float: left;
   width: 100%;
@@ -744,6 +768,7 @@ body.in-stats h2 {
   border: 0;
   text-align: center;
 }
+
 .zipcodes-table .table tr th {
   background: #f0f0f0;
 }
@@ -827,7 +852,9 @@ body.in-stats h2 {
   margin-bottom: 10px;
 }
 
-.chosen-single, .chosen-choices, .date-range.filter {
+.chosen-single,
+.chosen-choices,
+.date-range.filter {
   border: 1px solid black !important;
   min-height: 30px !important;
   padding-left: 10px !important;

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -394,28 +394,21 @@ body.in-stats .background-container,
 }
 
 .partnerLogos {
+  .logo-container {
+    text-align: center;
+  }
   a {
+    display: inline-block;
+    width: 20%;
+    margin: 0 2%;
+
     img {
       display: inline-block;
-      margin-right: 2%;
-    }
-    &:first-child img {
-      width: 14%;
-    }
-    &:nth-child(2) img {
-      width: 15%;
-    }
-    &:nth-child(3) img {
-      width: 25%;
-    }
-    &:last-child img {
-      width: 30%;
-      margin-right: 0;
+      width: 100%;
     }
   }
   p {
-    margin-top: 10px;
-    margin-bottom: 0
+    margin: 0.75em 0 0.5em;
   }
   ul {
     padding: 0 5%;
@@ -809,7 +802,7 @@ body.in-stats h2 {
 .brought-by {
   font-size: 24px;
   text-align: center;
-  padding: 20px 0;
+  padding-bottom: 0.25em;
 }
 
 .footer-logo img {

--- a/app/assets/stylesheets/responsive.scss
+++ b/app/assets/stylesheets/responsive.scss
@@ -1,9 +1,10 @@
-@media only screen and (min-width: 768px){
+@media only screen and (min-width: 768px) {
   .navbar {
     border-radius: 0 !important;
   }
 }
-@media only screen and (min-width : 320px) and (max-width : 768px){
+
+@media only screen and (min-width: 320px) and (max-width: 768px) {
   .title-container h1 {
     font-size: 24px
   }
@@ -34,13 +35,13 @@
     display: none;
   }
 
-  .social-share-btn, .resultTableForDesktop .social-share-btn {
+  .social-share-btn,
+  .resultTableForDesktop .social-share-btn {
     display: block;
     margin: 10px 0;
     padding: 12px 45px 12px 6px;
     text-align: center;
   }
-
 
   .background-container {
     padding: 0 10px 0 10px;
@@ -79,7 +80,7 @@
   float: right;
 }
 
-@media only screen and (max-width : 880px){
+@media only screen and (max-width: 880px) {
   .social-share-btn {
     padding: 12px 18px 12px 6px;
   }
@@ -90,8 +91,8 @@
   }
 }
 
-@media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
-  h2{
+@media only screen and (min-device-width: 320px) and (max-device-width: 480px) {
+  h2 {
     font-size: 22px !important;
   }
 
@@ -125,7 +126,9 @@
     }
   }
 
-  .social-share-button-twitter, .social-share-button-facebook, .social-share-button-linkedin {
+  .social-share-button-twitter,
+  .social-share-button-facebook,
+  .social-share-button-linkedin {
     border: none;
   }
 
@@ -143,10 +146,10 @@
   }
 
   #introduction {
-    li{
+    li {
       width: 48%;
 
-      a{
+      a {
         width: 70%
       }
     }
@@ -155,10 +158,9 @@
   .powerUpImmg {
     width: 50%
   }
-  .title-container
-    h1 {
-      font-size: 18px
-    }
+  .title-container h1 {
+    font-size: 18px
+  }
   .navbar-header {
     p {
       font-size: 16px
@@ -212,42 +214,44 @@
   .powerLogo img {
     width:130px;
   }
-  #all-results{
-      h2 {
-        font-size: 18px
-      }
-      table
-        th {
-          font-size: 12px
-        }
+  #all-results {
+    h2 {
+      font-size: 18px
     }
-    div#map {
-      width:100%;
-      height: 300px !important;
+    table
+    th {
+      font-size: 12px
     }
-    div#map-filters {
-      width: 100%
-    }
+  }
+  div#map {
+    width:100%;
+    height: 300px !important;
+  }
+  div#map-filters {
+    width: 100%
+  }
 }
 
-@media only screen and (min-device-width : 992px) and (max-device-width : 1299px){
+@media only screen and (min-device-width: 992px) and (max-device-width: 1299px) {
   .rating-sm {
     font-size: 1.7em;
   }
 }
- .navbar-text {
+
+.navbar-text {
   margin: 10px 5px 2px 0 !important;
   font-size: 20px;
- }
-.navbar-brand{
+}
+
+.navbar-brand {
   padding-right: 5px !important;
   padding-top: 12px !important
 }
 
 @media only screen
-and (min-device-width : 768px)
-and (max-device-width : 1024px)
-and (orientation : landscape)
+and (min-device-width: 768px)
+and (max-device-width: 1024px)
+and (orientation: landscape)
 and (-webkit-min-device-pixel-ratio: 1) {
   .rating-sm {
     font-size: inherit;
@@ -258,8 +262,9 @@ and (-webkit-min-device-pixel-ratio: 1) {
   }
 }
 
-@media only screen and (min-device-width : 768px) and (max-device-width : 900px){
-  table td[class*="col-"], table th[class*="col-"] {
+@media only screen and (min-device-width: 768px) and (max-device-width: 900px) {
+  table td[class*="col-"],
+  table th[class*="col-"] {
     font-size: 12px
   }
 }
@@ -268,7 +273,7 @@ and (-webkit-min-device-pixel-ratio: 1) {
 /*=====================RESPONSIVENESS SPEEDTEST=========================*/
 
 
-@media only screen and (max-width: 1024px){
+@media only screen and (max-width: 1024px) {
   body.in-stats h1  {
     font-size: 30px;
   }
@@ -308,11 +313,11 @@ and (-webkit-min-device-pixel-ratio: 1) {
   }
 }
 
-@media only screen and (max-width: 767px){
+@media only screen and (max-width: 767px) {
   .mobile-mrg-bottom-30 {
     margin-bottom: 30px;
   }
-    ul.header-links {
+  ul.header-links {
     background: white;
     margin-top: 0;
   }
@@ -350,7 +355,8 @@ and (-webkit-min-device-pixel-ratio: 1) {
     color: black;
   }
 }
-@media only screen and (max-width: 736px){
+
+@media only screen and (max-width: 736px) {
   .stats-header {
     font-size: 20px;
   }

--- a/app/views/home/_introduction.html.erb
+++ b/app/views/home/_introduction.html.erb
@@ -28,15 +28,9 @@
 
   <div class='row'>
     <div class='col-lg-7 col-xs-11 col-sm-9 col-centered'>
-      <div class='partnerLogos'>
-        <p>SpeedUpAmerica partners:</p>
-
-        <div class='row'>
-          <%= link_to image_tag('companyLogos/tao.png'), 'http://www.techoregon.org/' %>
-          <%= link_to image_tag('companyLogos/us_ignite.jpg'), 'https://www.us-ignite.org/' %>
-          <%= link_to image_tag('companyLogos/m_lab.png'), 'https://www.measurementlab.net/' %>
-        </div>
-      </div>
+      <%= render partial: 'shared/partners', locals: {
+        label: 'SpeedUpAmerica partners:'
+      } %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_partners.html.erb
+++ b/app/views/shared/_partners.html.erb
@@ -1,0 +1,23 @@
+<div class="partnerLogos">
+  <%= content_tag :p, label, class: (class_name if local_assigns[:class_name]) %>
+
+  <div class="logo-container">
+    <%= link_to(
+      image_tag('companyLogos/tao.png', alt: 'Technology Association of Oregon'),
+      'http://www.techoregon.org/',
+      target: '_blank'
+    ) %>
+
+    <%= link_to(
+      image_tag('companyLogos/us_ignite.jpg', alt: 'US Ignite'),
+      'https://www.us-ignite.org/',
+      target: '_blank'
+    ) %>
+
+    <%= link_to(
+      image_tag('companyLogos/m_lab.png', alt: 'M-Lab'),
+      'https://www.measurementlab.net/',
+      target: '_blank'
+    ) %>
+  </div>
+</div>

--- a/app/views/submissions/_stats_footer.html.erb
+++ b/app/views/submissions/_stats_footer.html.erb
@@ -1,17 +1,10 @@
 <div class="container">
   <div class='row'>
     <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12 footer-logo'>
-      <div class="brought-by">This infographic and SpeedUpAmerica, are brought to you by:</div>
-
-      <div class="row">
-      <div class="col-xs-12 col-sm-10 col-md-8 col-lg-8 col-centered">
-        <div class='col-xs-6 col-sm-6 col-md-6 col-lg-6'>
-          <%= link_to 'https://www.measurementlab.net/', target: '_blank' do %>
-            <%= image_tag 'companyLogos/m_lab.png' %>
-          <% end %>
-        </div>
-      </div>
-      </div>
+      <%= render partial: 'shared/partners', locals: {
+        label: 'This infographic and SpeedUpAmerica, are brought to you by:',
+        class_name: 'brought-by'
+      } %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
M-Lab was already shown, but the others were missing on this page.

The implementation of this patch includes the following:

* Create a new partial for showing partner logos.
* Use the new partial on the home page as well as the results page.
* Explicitly define `alt` attributes for each image.
* Display each logo at the same size (specifically, the same width).

I also did a little cleanup on indentation and whitespace use in `home.scss` and `responsive.scss`. That was the first commit from this PR, so just look at the second commit for the functional changes.

Closes #69 