### PR TITLE
 Add zoom controls to the map

### DIFF
--- a/app/assets/javascripts/mlab.js
+++ b/app/assets/javascripts/mlab.js
@@ -31,15 +31,6 @@ function addLegend() {
     return div;
   };
 
-/*
-      for ( var i = 0; i < grades.length; i++ ) {
-          div.innerHTML +=
-              '<i style="background:' + getPolygonColor(grades[i] + 1) +
-        '"></i> ' + (i == 0 ? '0' : grades[i]) + (grades[i + 1] ?
-        '&ndash;' + grades[i + 1] + ' Mbps<br/>' : '+ Mbps');
-      }
-      return div;
-*/
   legend.addTo(map);
 }
 
@@ -394,18 +385,6 @@ function closeAllTheThings() {
   $('#ndt, #ndt-results, #extra-data, #about-ndt').hide();
 }
 
-
-
-function showHideControls() {
-  $('.leaflet-bottom.leaflet-left, #sidebar, #approx-loc').toggle();
-  if ($('#header').hasClass('initial')) {
-    $('.leaflet-bottom.leaflet-right').hide();
-  } else if ($(document).width() > 700) {
-    $('#layers-box, .leaflet-bottom.leaflet-right').show();
-    $('.leaflet-top.leaflet-left').show();
-  }
-}
-
 function showTestingPanel() {
   // are there results yet?
   var results = document.getElementById('s2cRate');
@@ -433,41 +412,6 @@ function showTestingPanel() {
     $('.metricControls, .sliderElements, .leaflet-control-layers').hide();
   }
 
-}
-
-/* New functions */
-function runTest() {
-  $('#ndt-div').removeClass('hidden');
-  $('#ndt-div').addClass('visible');
-  $('#extra-data').removeClass('visible');
-  $('#extra-data').addClass('hidden');
-  $('#approx-loc').removeClass('hidden');
-  $('#approx-loc').addClass('visible');
-  $('#ndt-results').removeClass('hidden');
-  $('#ndt-results').addClass('visible');
-  $('#intro').addClass('hidden');
-  $('#icons').addClass('hidden');
-  $('#header').removeClass('initial');
-  $('#header').addClass('hidden');
-  window.scrollTo(0, 0);
-}
-function showMap() {
-  $('#icons img').removeClass('selected');
-  $('#header').removeClass('initial');
-  $('#welcome-container, #header, #intro, #sidebar, #approx-loc, #ndt-div').addClass('hidden');
-  $('#mobile-container').addClass('hidden');
-  if ($(document).width() < 700) {
-    $('.leaflet-control-layers').addClass('hidden');
-  }
-  $('#layers-box').show();
-  $('.leaflet-top.leaflet-left, .leaflet-top.leaflet-right').show();
-  // for #114
-  getCurrentValues();
-
-}
-function showSocialShare() {
-  $('#socialshare').removeClass('hidden');
-  $('#socialshare').addClass('visible');
 }
 
 $( window ).resize(function() {
@@ -509,29 +453,7 @@ $(function() {
     closeAllTheThings();
     $('#mobile-container, .sliderElements, .metricControls, #desktop-legend, .leaflet-control-layers').toggle();
   });
-  /*
-  $('#exploreMap').click(function() {
-    showHideControls();
-    $('#header').addClass('hidden');
-    $('#layers-box').show();
-    $('.leaflet-top.leaflet-left, .leaflet-top.leaflet-right').show();
-    $('#testSpeed, #exploreMap').toggle();
-  });
-  $('#testSpeed').click(function() {
-    showHideControls();
-    showTestingPanel();
-    $('#header').addClass('hidden');
-    $('#layers-box').show();
-    $('.leaflet-top.leaflet-left').show();
-    $('#testSpeed, #exploreMap').toggle();
-  });
-  $('#testSpeedEmptyPrompt').click(function() {
-    $('#header').removeClass('initial');
-    showHideControls();
-    showTestingPanel();
-    $('#testSpeed, #exploreMap').toggle();
-  });
-  */
+
   $('#isp_user, #connection_type, #cost_of_service, #data_acknowledgement').change(function() {
     var formState = validateExtraDataForm();
     $('#take-test').toggle(formState);

--- a/app/assets/javascripts/mlab.js
+++ b/app/assets/javascripts/mlab.js
@@ -428,7 +428,7 @@ $( window ).resize(function() {
 
 $(function() {
   /* Sets initial status on load for various divs */
-  $('#testSpeed, #desktop-legend, .info.legend.leaflet-control, .leaflet-bottom.leaflet-left, .info.controls.leaflet-control, #socialshare, .leaflet-top.leaflet-left, .leaflet-top.leaflet-right, .leaflet-control-layers').addClass('hidden');
+  $('#testSpeed, #desktop-legend, .info.legend.leaflet-control, .leaflet-bottom.leaflet-left, .info.controls.leaflet-control, #socialshare, .leaflet-top.leaflet-right, .leaflet-control-layers').addClass('hidden');
   //$('.leaflet-top.leaflet-right').attr('id','layers-box');
   $('#header').addClass('initial');
 

--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -12,7 +12,7 @@ body.result-page {
   padding-top: 200px;
   height: 702px;
   position: absolute;
-  z-index: 10;
+  z-index: 2000; // Mapbox zoom controls have a z-index of 1000
   background-color: white;
 }
 


### PR DESCRIPTION
The zoom controls were already being loaded, but they were hidden when the page loaded by hiding their container which has the classes `leaflet-top` and `leaflet-left`.

Mapbox's CSS sets zoom controls' `z-index` to 1000, so I needed to raise the loading spinner in order to cover them.

Closes #46