### PR TITLE
Add rel="noopener" to links that use target="_blank"

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -457,7 +457,7 @@ body.in-stats .background-container,
   margin-top: 20px;
 }
 
-.speeduplou {
+.speedup-hashtag {
   font-size: 18px;
 }
 

--- a/app/views/home/_form_step_1.html.erb
+++ b/app/views/home/_form_step_1.html.erb
@@ -23,6 +23,6 @@
 
   <div class='text-center find-more-div'>
     Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank' %>
+    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
   </div>
 </div>

--- a/app/views/home/_form_step_2a.html.erb
+++ b/app/views/home/_form_step_2a.html.erb
@@ -89,6 +89,6 @@
 
   <div class='text-center find-more-div'>
     Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank' %>
+    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
   </div>
 </div>

--- a/app/views/home/_form_step_2b.html.erb
+++ b/app/views/home/_form_step_2b.html.erb
@@ -34,6 +34,6 @@
 
   <div class='text-center find-more-div'>
     Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank' %>
+    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
   </div>
 </div>

--- a/app/views/home/_form_step_2c.html.erb
+++ b/app/views/home/_form_step_2c.html.erb
@@ -24,6 +24,6 @@
 
   <div class='text-center find-more-div'>
     Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank' %>
+    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
   </div>
 </div>

--- a/app/views/home/_introduction.html.erb
+++ b/app/views/home/_introduction.html.erb
@@ -23,7 +23,7 @@
 
   <div class='text-center find-more-div'>
     Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank' %>
+    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
   </div>
 
   <div class='row'>

--- a/app/views/shared/_partners.html.erb
+++ b/app/views/shared/_partners.html.erb
@@ -5,25 +5,29 @@
     <%= link_to(
       image_tag('companyLogos/eugene.png', alt: 'City of Eugene, OR'),
       'https://www.eugene-or.gov/',
-      target: '_blank'
-	) %>
+      target: '_blank',
+      rel: 'noopener'
+    ) %>
 
     <%= link_to(
       image_tag('companyLogos/tao.png', alt: 'Technology Association of Oregon'),
       'http://www.techoregon.org/',
-      target: '_blank'
+      target: '_blank',
+      rel: 'noopener'
     ) %>
 
     <%= link_to(
       image_tag('companyLogos/us_ignite.jpg', alt: 'US Ignite'),
       'https://www.us-ignite.org/',
-      target: '_blank'
+      target: '_blank',
+      rel: 'noopener'
     ) %>
 
     <%= link_to(
       image_tag('companyLogos/m_lab.png', alt: 'M-Lab'),
       'https://www.measurementlab.net/',
-      target: '_blank'
+      target: '_blank',
+      rel: 'noopener'
     ) %>
   </div>
 </div>

--- a/app/views/shared/_social_sharing_links.html.erb
+++ b/app/views/shared/_social_sharing_links.html.erb
@@ -3,7 +3,8 @@
   <%= link_to(
     "https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.facebook.com%2FSpeed-Up-America-416927695803950%2F",
     class: 'social-share-btn',
-    target: '_blank'
+    target: '_blank',
+    rel: 'noopener'
   ) do %>
     <%= image_tag 'facebook.png', width: 21 %> Share on Facebook
   <% end %>
@@ -11,7 +12,8 @@
   <%= link_to(
     "https://twitter.com/share?text=I just tested my internet speed with Speed Up America! Check it out here:&url=#{request.url}&hashtags=speedupamerica",
     class: 'social-share-btn',
-    target: '_blank'
+    target: '_blank',
+    rel: 'noopener'
   ) do %>
     <%= image_tag 'twitter.png', width: 21 %> Share on Twitter
   <% end %>
@@ -19,7 +21,8 @@
   <%= link_to(
     "https://www.linkedin.com/sharing/share-offsite/?url=speedupamerica.com",
     class: 'social-share-btn',
-    target: '_blank'
+    target: '_blank',
+    rel: 'noopener'
   ) do %>
     <%= image_tag 'linkedin.png', width: 21 %> Share on LinkedIn
   <% end %>

--- a/app/views/shared/_social_sharing_links.html.erb
+++ b/app/views/shared/_social_sharing_links.html.erb
@@ -1,12 +1,26 @@
 <div class='social-sharing-links'>
-  <span class='speeduplou'>#SpeedUpAmerica </span>
-  <%= link_to "https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.facebook.com%2FSpeed-Up-America-416927695803950%2F", class:'social-share-btn', target: '_blank' do %>
+  <span class='speedup-hashtag'>#SpeedUpAmerica </span>
+  <%= link_to(
+    "https://www.facebook.com/sharer.php?u=https%3A%2F%2Fwww.facebook.com%2FSpeed-Up-America-416927695803950%2F",
+    class: 'social-share-btn',
+    target: '_blank'
+  ) do %>
     <%= image_tag 'facebook.png', width: 21 %> Share on Facebook
   <% end %>
-  <%= link_to "https://twitter.com/share?text=I just tested my internet speed with Speed Up America! Check it out here:&url=#{request.url}&hashtags=speedupamerica", class: 'social-share-btn', target: '_blank' do %>
-  <%= image_tag 'twitter.png', width: 21 %> Share on Twitter
+
+  <%= link_to(
+    "https://twitter.com/share?text=I just tested my internet speed with Speed Up America! Check it out here:&url=#{request.url}&hashtags=speedupamerica",
+    class: 'social-share-btn',
+    target: '_blank'
+  ) do %>
+    <%= image_tag 'twitter.png', width: 21 %> Share on Twitter
   <% end %>
-  <%= link_to "https://www.linkedin.com/sharing/share-offsite/?url=speedupamerica.com", class:'social-share-btn', target: '_blank' do %>
-  <%= image_tag 'linkedin.png', width: 21 %> Share on LinkedIn
+
+  <%= link_to(
+    "https://www.linkedin.com/sharing/share-offsite/?url=speedupamerica.com",
+    class: 'social-share-btn',
+    target: '_blank'
+  ) do %>
+    <%= image_tag 'linkedin.png', width: 21 %> Share on LinkedIn
   <% end %>
 </div>

--- a/app/views/submissions/_about_speedup.html.erb
+++ b/app/views/submissions/_about_speedup.html.erb
@@ -12,7 +12,7 @@
 
     <div class='col-xs-12 col-sm-12 col-md-6 col-lg-6'>
       <div class='banner-text results-banner-text'>
-        SpeedUpAmerica helps Americans understand the quality and cost of their internet service. We do not collect any personal data. By providing your location, you can help reveal which areas of America have slow or overpriced internet. 
+        SpeedUpAmerica helps Americans understand the quality and cost of their internet service. We do not collect any personal data. By providing your location, you can help reveal which areas of America have slow or overpriced internet.
       </div>
     </div>
   </div>
@@ -22,6 +22,6 @@
 
   <div class='text-center find-more-div'>
     Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank' %>
+    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
 </div>
 </div>


### PR DESCRIPTION
I considered creating a new partial for all of the files that link to the GitHub repo with an identical block. I didn't go that route since I figured the quick, duplicated solution would work for now, since we'll be revamping the whole frontend soon. Let me know if you'd like me to update this PR to use a partial for that instead.

This PR also does a little cleanup on `app/views/shared/_social_sharing_links.html.erb`:

* Change linebreaks from `\r\n` to `\n`
* Break long lines
* Rename a CSS class from `speeduplou` to `speedup-hashtag` (since this repo is no longer SpeedUpLouisville)

Closes #117 