### PR TITLE
Boundaries table, Census Block loading, and boundary population

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,7 @@
 #################
 keys/*
 db/data/*
-data/cb_2016_us_census_tracts
-data/cb_2016_us_census_tracts.json
-data/us_zip_codes.json
+data/*
 
 # Elastic Beanstalk Files #
 ###########################

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Use and set the Default pulic token as your `MAPBOX_API_KEY` in the `local.env`f
 
 Download this SQL file and place it in the projects `data` directory:
 
-* https://sua-datafiles.s3-us-west-2.amazonaws.com/suyc_20190803.sql
+* https://sua-datafiles.s3-us-west-2.amazonaws.com/sua_20190803.sql
 
 > Contributors: If you update this file make sure to change the filename and
 > update all references in this document.
@@ -105,7 +105,7 @@ Download this SQL file and place it in the projects `data` directory:
 Run this line:
 
 ```bash
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/suyc_20190803.sql
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/sua_20190803.sql
 ```
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The goal of this project is to increase awareness of inequities in speed and qua
 
 Welcome!
 
-_The current implementation of SpeedUpAmerica has scaled to cover the state of Oregon (June 2019), with Washington and Idaho to come online next (July 2019)._
+_The current implementation of SpeedUpAmerica has scaled to cover the state of Oregon in June 2019. Washington and Idaho were added in July 2019. State and county boundaries are being added sometime during August 2019._
 
 ## Digital Inclusion
 

--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ $ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc --ign
 
 ## Updating your boundaries the long way
 
-Follow the next three sections to get the latest data, clear your
-boundaries tables, and load data from the files. You should only be following
-these directions if dumping your DB and loading the lastest SQL dump is not
+Follow the next three sections to download the latest data, clear your
+boundaries tables, and load the data. You should only be following
+these directions if deleting your DB and loading the lastest SQL dump is not
 an option.
 
 ### Download boundary data files

--- a/README.md
+++ b/README.md
@@ -67,12 +67,11 @@ Install [Git](https://git-scm.com/downloads) Windows/Mac/Linux
 
 Install [Docker](https://docs.docker.com/install/#supported-platforms) and [Docker Compose](https://docs.docker.com/compose/install/) (Docker Compose is already included with Mac and Windows Docker installs, but not Linux. Please also note the Win Home install differs from Pro).
 
-> A minimum of 4GB of local memory allocation is needed for some tasks to run. After starting Docker, go into it's settings and adjust the amount of memory it's allowed to use.
-
-[Memory - Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/#memory)
-
-[Memory - Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/)
-
+> A minimum of 6GB of local memory allocation is needed. After starting Docker, go into it's settings and adjust the amount of memory it's allowed to use.
+>
+> [Memory - Docker Desktop for Mac](https://docs.docker.com/docker-for-mac/#memory)
+>
+> [Memory - Docker Desktop for Windows](https://docs.docker.com/docker-for-windows/)
 
 > Depending on your OS, you may have to make sure to use `copy` instead of `cp`.
 
@@ -94,26 +93,19 @@ Use and set the Default pulic token as your `MAPBOX_API_KEY` in the `local.env`f
 
 > These instructions assume Windows users are not using the WSL, which has documented problems with Docker's bind mounts. Installing and configuring Docker for Windows to work with the WSL is outside the scope of this document.
 
-## Load an initial dataset
+## Load the dataset
 
-Download these files and place them in the projects `data` directory:
+Download this SQL file and place it in the projects `data` directory:
 
-* https://sua-datafiles.s3-us-west-2.amazonaws.com/zip_codes.sql
-* https://sua-datafiles.s3-us-west-2.amazonaws.com/census_tracts.sql
-* https://sua-datafiles.s3-us-west-2.amazonaws.com/submissions.sql
-* https://sua-datafiles.s3-us-west-2.amazonaws.com/stats_caches.sql
-* https://sua-datafiles.s3-us-west-2.amazonaws.com/boundaries.sql
+* https://sua-datafiles.s3-us-west-2.amazonaws.com/suyc_20190803.sql
 
-Run these lines:
+> Contributors: If you update this file make sure to change the filename and
+> update all references in this document.
+
+Run this line:
 
 ```bash
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/zip_codes.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/submissions.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/stats_caches.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/boundariess.sql
-$ docker-compose run frontend rake update_providers_statistics
-$ docker-compose run frontend rake update_stats_cache
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/suyc_20190803.sql
 ```
 
 ## Running
@@ -145,6 +137,8 @@ $ docker-compose logs migrator
 $ docker-compose logs mysql
 ```
 
+## Frontend is exiting
+
 If `docker-compose ps` shows "Exit 1" for any process, one likely cause is that the process's Docker image needs to be rebuilt. This is generally due to dependencies having changed since the last time you built the image. An additional hint that this is the cause is if the logs show errors indicating that a dependency could not be found.
 
 To resolve this, rebuild the Docker image for that specific process. For example, if the `frontend` process exited with an error status:
@@ -157,18 +151,100 @@ If `docker-compose ps` continues to throw an "Exit 1" error for any process afte
 
 If after enabling your firewall persmissions you still have trouble with an "Exit 1", you may need to delete tmp/pids/server.pid and then `docker-compose up -d`
 
-### Running Docker on Ubuntu
+## Running Docker on Ubuntu
 Installation on [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
 
 Running the environment locally on a Linux-based OS could require running `docker-compose` commands as super user, `sudo docker-compose [commands]`.
 
 [Here is a guide for managing Docker as a non-root user](https://docs.docker.com/install/linux/linux-postinstall/).
 
-# Data tasks
+# Tasks contributors need to do occassionally
 
-There are just the tasks that have been run to populate and prepare the data for operation. The other tasks need investigated and documented.
+## Reload the database from most recent backup
 
-Most of theses tasks are run by `./update_data.sh` each night on Test and Production.
+> Assumes you have the recent `.sql` file downloaded from the setup instructions.
+
+When boundaries are updated each developer must reload their boundaries. As new boundaries
+can also require adding columns to the submissions table it's best to completely reload your
+database.
+
+```bash
+$ docker-compose stop mysql
+$ docker-compose rm mysql
+$ docker-compose up mysql
+$ docker-compose up --build migrator
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/sua_20190803.sql
+```
+
+## Creating database dump
+
+> When updating the SQL files make sure to remove the warning from the first line of the file.
+
+Make sure to replace `<date>` with todays date in a concise format (e.g. `20190801`).
+
+```bash
+$ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc --ignore-table=suyc.schema_migrations > data/sua_<date>.sql
+```
+
+## Updating your boundaries the long way
+
+Follow the next three sections to get the latest data, clear your
+boundaries tables, and load data from the files. You should only be following
+these directions if dumping your DB and loading the lastest SQL dump is not
+an option.
+
+### Download boundary data files
+
+Assumes you have these files in `data/`:
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/cb_2016_us_census_tracts
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/us_zip_codes.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_16_tabblock10.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_41_tabblock10.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_53_tabblock10.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_zcta510.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_county.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_state.json
+
+### Empty your boundaries tables
+
+For Linux and MacOS please use the following:
+
+```bash
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE zip_boundaries;"
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE census_boundaries;"
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE boundaries;"
+```
+
+For Windows OS please use the following:
+
+```
+$ docker-compose exec mysql mysql -u suyc -psuyc suyc
+$ mysql> TRUNCATE census_boundaries;
+$ mysql> TRUNCATE zip_boundaries;
+$ mysql> TRUNCATE boundaries;
+$ mysql> exit
+```
+
+### Load
+
+```
+$ docker-compose run frontend rake populate_zip_boundaries
+$ docker-compose run frontend rake populate_census_tracts
+$ docker-compose run frontend rake populate_boundaries
+```
+
+## Data import process
+
+Each night the Test and Production environments run the data import process, which imports
+recent M-Lab data, updates boundaries, recalcualtes the caches, and other data related tasks.
+
+> Some steps of the nightly import process requires a BigQuery Service Key with access to the Measurement Lab data.
+
+The nightly process is start by running `./update_data.sh`. On your local enviornment you can:
+
+```bash
+$ docker-compose run frontend ./update_data.sh
+```
 
 ### Importing M-Lab submissions:
 
@@ -178,10 +254,10 @@ Requires a BigQuery Service Key with access to the Measurement Lab data.
 $ docker-compose run frontend rake import_mlab_submissions
 ```
 
-### Populating submissions with Census Tract IDs
+### Populating submissions with missing boundaries
 
 ```bash
-$ docker-compose run frontend rake update_pending_census_codes
+$ docker-compose run frontend rake populate_missing_boundaries
 ```
 
 ### Updating provider statistics
@@ -194,80 +270,6 @@ $ docker-compose run frontend rake update_providers_statistics
 
 ```
 $ docker-compose run frontend rake update_stats_cache
-```
-
-## Loading new boundaries
-
-> Assumes you have recent `.sql` files downloaded from links in setup instructions.
-
-When boundaries are updated each developer must reload their boundary tables:
-
-```bash
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE census_boundaries;"
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE zip_boundaries;"
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE boundaries;"
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/zip_codes.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/boundaries.sql
-```
-
->For Windows OS please use the following:
-```bash
-$ docker-compose exec mysql mysql -u suyc -psuyc suyc
-$ mysql> TRUNCATE census_boundaries;
-$ mysql> TRUNCATE zip_boundaries;
-$ mysql> TRUNCATE boundaries;
-$ mysql> exit
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/zip_codes.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sql
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/boundaries.sql
-```
-
-### Updating the Census and Zip Code boundaries SQL files
-
-Assumes you have these files in `data/`:
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/cb_2016_us_census_tracts
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/us_zip_codes.json
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_16_tabblock10.json
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_41_tabblock10.json
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_53_tabblock10.json
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_zcta510.json
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_county.json
-* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_state.json
-
-```bash
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE zip_boundaries;"
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE census_boundaries;"
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE boundaries;"
-$ docker-compose run frontend rake populate_zip_boundaries
-$ docker-compose run frontend rake populate_census_tracts
-$ docker-compose run frontend rake populate_census_blocks
-```
-
-> When updating the SQL files make sure to remove the warning from the first line of the file.
-
-Once imported you can update the SQL files by:
-```bash
-$ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc census_boundaries > data/census_tracts.sql
-$ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc zip_boundaries > data/zip_codes.sql
-$ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc boundaries > data/boundaries.sql
-```
-
-### Creating new submissions.sql
-
-> When updating the SQL files make sure to remove the warning from the first line of the file.
-
-```bash
-$ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc submissions > data/submissions.sql
-```
-
-### Creating new stats_caches.sql
-
-> When updating the SQL files make sure to remove the warning from the first line of the file.
-
-```bash
-$ docker-compose run frontend rake update_stats_cache
-$ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc stats_caches > data/stats_caches.sql
 ```
 
 # Governance and contribution

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ docker-compose run frontend rake secret
 
 Locate your `local.env` in the root of the SpeedUpAmerica directory which now resides on your local system.
 Use the long alphanermeric string output from `rake secret` as the value for `SECRET_KEY_BASE`.
-Go to [Mapbox](https://account.mapbox.com) and create a free account, to get a mapbox api access token. 
+Go to [Mapbox](https://account.mapbox.com) and create a free account, to get a mapbox api access token.
 Use and set the Default pulic token as your `MAPBOX_API_KEY` in the `local.env`file.
 
 > These instructions assume Windows users are not using the WSL, which has documented problems with Docker's bind mounts. Installing and configuring Docker for Windows to work with the WSL is outside the scope of this document.
@@ -102,6 +102,7 @@ Download these files and place them in the projects `data` directory:
 * https://sua-datafiles.s3-us-west-2.amazonaws.com/census_tracts.sql
 * https://sua-datafiles.s3-us-west-2.amazonaws.com/submissions.sql
 * https://sua-datafiles.s3-us-west-2.amazonaws.com/stats_caches.sql
+* https://sua-datafiles.s3-us-west-2.amazonaws.com/boundaries.sql
 
 Run these lines:
 
@@ -110,6 +111,7 @@ $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/zip_codes.sql
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sql
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/submissions.sql
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/stats_caches.sql
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/boundariess.sql
 $ docker-compose run frontend rake update_providers_statistics
 $ docker-compose run frontend rake update_stats_cache
 ```
@@ -188,7 +190,7 @@ $ docker-compose run frontend rake update_pending_census_codes
 $ docker-compose run frontend rake update_providers_statistics
 ```
 
-### Updating cached data 
+### Updating cached data
 
 ```
 $ docker-compose run frontend rake update_stats_cache
@@ -219,12 +221,17 @@ $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sq
 Assumes you have these files in `data/`:
 * https://s3-us-west-2.amazonaws.com/sua-datafiles/cb_2016_us_census_tracts
 * https://s3-us-west-2.amazonaws.com/sua-datafiles/us_zip_codes.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_16_tabblock10.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_41_tabblock10.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_53_tabblock10.json
 
-```bash 
-$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE census_boundaries;"
+```bash
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE zip_boundaries;"
-$ docker-compose run frontend rake populate_census_tracts
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE census_boundaries;"
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE boundaries;"
 $ docker-compose run frontend rake populate_zip_boundaries
+$ docker-compose run frontend rake populate_census_tracts
+$ docker-compose run frontend rake populate_census_blocks
 ```
 
 > When updating the SQL files make sure to remove the warning from the first line of the file.

--- a/README.md
+++ b/README.md
@@ -198,12 +198,17 @@ $ docker-compose run frontend rake update_stats_cache
 
 ## Loading new boundaries
 
+> Assumes you have recent `.sql` files downloaded from links in setup instructions.
+
 When boundaries are updated each developer must reload their boundary tables:
+
 ```bash
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE census_boundaries;"
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE zip_boundaries;"
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE boundaries;"
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/zip_codes.sql
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sql
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/boundaries.sql
 ```
 
 >For Windows OS please use the following:
@@ -211,9 +216,11 @@ $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sq
 $ docker-compose exec mysql mysql -u suyc -psuyc suyc
 $ mysql> TRUNCATE census_boundaries;
 $ mysql> TRUNCATE zip_boundaries;
+$ mysql> TRUNCATE boundaries;
 $ mysql> exit
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/zip_codes.sql
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/census_tracts.sql
+$ docker-compose exec -T mysql mysql -u suyc -psuyc suyc < data/boundaries.sql
 ```
 
 ### Updating the Census and Zip Code boundaries SQL files
@@ -224,6 +231,9 @@ Assumes you have these files in `data/`:
 * https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_16_tabblock10.json
 * https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_41_tabblock10.json
 * https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_53_tabblock10.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_zcta510.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_county.json
+* https://s3-us-west-2.amazonaws.com/sua-datafiles/tl_2018_us_state.json
 
 ```bash
 $ docker-compose exec -T mysql mysql -u suyc -psuyc suyc <<< "TRUNCATE zip_boundaries;"
@@ -240,6 +250,7 @@ Once imported you can update the SQL files by:
 ```bash
 $ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc census_boundaries > data/census_tracts.sql
 $ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc zip_boundaries > data/zip_codes.sql
+$ docker-compose exec mysql mysqldump --no-create-info -u suyc -psuyc suyc boundaries > data/boundaries.sql
 ```
 
 ### Creating new submissions.sql

--- a/app/classes/submissions_importer.rb
+++ b/app/classes/submissions_importer.rb
@@ -154,14 +154,18 @@ class SubmissionsImporter
       submission.address             = row[:city]
       submission.zip_code            = row[:postal_code]
       submission.hostname            = row[:client_hostname]
-      submission.latitude            = row[:client_latitude]
-      submission.longitude           = row[:client_longitude]
-      submission.provider            = submission.get_provider
       submission.actual_down_speed   = row[:downloadThroughput]
       submission.actual_upload_speed = row[:uploadThroughput]
-      submission.census_status       = Submission::CENSUS_STATUS[:pending]
 
+      submission.provider            = submission.get_provider
+
+      submission.latitude            = row[:client_latitude]
+      submission.longitude           = row[:client_longitude]
+      submission.location            = nil
       submission.save
+
+      submission.populate_location
+      submission.populate_boundaries
     end
   end
 

--- a/app/classes/submissions_importer.rb
+++ b/app/classes/submissions_importer.rb
@@ -164,6 +164,7 @@ class SubmissionsImporter
       submission.location            = nil
       submission.save
 
+      # These execute update queries using the new submissions id
       submission.populate_location
       submission.populate_boundaries
     end

--- a/app/models/boundaries.rb
+++ b/app/models/boundaries.rb
@@ -1,0 +1,3 @@
+class Boundaries < ActiveRecord::Base
+  self.primary_keys = :boundary_type, :boundary_id
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -7,8 +7,6 @@ class Submission < ActiveRecord::Base
   obfuscate_id spin: 81238123
   MOBILE_MAXIMUM_SPEED = 50
 
-  CENSUS_STATUS = { pending: 'pending', saved: 'saved' }
-
   MAP_FILTERS = {
     connection_type: {
       home_wifi: 'Home Wifi',
@@ -93,7 +91,6 @@ class Submission < ActiveRecord::Base
     submission.completed = true
     submission.test_id = [Time.now.utc.to_i, SecureRandom.hex(10)].join('_')
     submission.provider = submission.get_provider
-    submission.census_status = Submission::CENSUS_STATUS[:pending]
     submission.save
 
     submission.populate_location
@@ -788,8 +785,6 @@ class Submission < ActiveRecord::Base
       "ST_Contains(geometry, (SELECT location FROM submissions WHERE id = #{id} LIMIT 1));"
     result = conn.select_rows(query)
 
-    self.assign_attributes(:census_status => Submission::CENSUS_STATUS[:pending])
-
     result.each do |row|
       case row[0]
       when 'region'
@@ -801,7 +796,6 @@ class Submission < ActiveRecord::Base
         self.assign_attributes(:zip_code => row[1])
       when 'census_tract'
         self.assign_attributes(:census_code => row[1])
-        self.assign_attributes(:census_status => Submission::CENSUS_STATUS[:saved])
       when 'census_block'
         self.assign_attributes(:census_block => row[1])
       end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -792,7 +792,7 @@ class Submission < ActiveRecord::Base
 
     result.each do |row|
       case row[0]
-      when 'state'
+      when 'region'
         self.assign_attributes(:region => row[1])
         self.assign_attributes(:country_code => 'US')
       when 'county'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,10 +12,10 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - echo Building the Docker image... 
+      - echo Building the Docker image...
       - chmod +x ./update_data.sh
       - echo Getting latest GeoLite2 ASN DB
-      - wget https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz 
+      - wget https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz
       - tar -xf GeoLite2-ASN.tar.gz
       - cp GeoLite2-ASN_*/GeoLite2-ASN.mmdb .
       - rm -r GeoLite2-ASN_*
@@ -25,6 +25,9 @@ phases:
       - mkdir -p data
       - aws s3 cp s3://sua-datafiles/cb_2016_us_census_tracts.json data/cb_2016_us_census_tracts.json
       - aws s3 cp s3://sua-datafiles/us_zip_codes.json data/us_zip_codes.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_16_tabblock10.json data/tl_2018_16_tabblock10.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_41_tabblock10.json data/tl_2018_41_tabblock10.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_53_tabblock10.json data/tl_2018_53_tabblock10.json
       - docker build -t $REPOSITORY_URI:latest .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -28,6 +28,12 @@ phases:
       - aws s3 cp s3://sua-datafiles/tl_2018_16_tabblock10.json data/tl_2018_16_tabblock10.json
       - aws s3 cp s3://sua-datafiles/tl_2018_41_tabblock10.json data/tl_2018_41_tabblock10.json
       - aws s3 cp s3://sua-datafiles/tl_2018_53_tabblock10.json data/tl_2018_53_tabblock10.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_16_tract.json data/tl_2018_16_tract.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_41_tract.json data/tl_2018_41_tract.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_53_tract.json data/tl_2018_53_tract.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_us_zcta510.json data/tl_2018_us_zcta510.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_us_county.json data/tl_2018_us_county.json
+      - aws s3 cp s3://sua-datafiles/tl_2018_us_state.json data/tl_2018_us_state.json
       - docker build -t $REPOSITORY_URI:latest .
       - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
   post_build:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   #config.log_tags = [ :subdomain, :uuid ]

--- a/lib/tasks/census_tract_boundaries.rake
+++ b/lib/tasks/census_tract_boundaries.rake
@@ -37,22 +37,6 @@ task :populate_census_tracts => [:environment] do
       # increment the count
       add_count += 1
     end
-
-    # if not in Boundaries, add it
-    if Boundaries.where(boundary_type: 'census_tract', boundary_id: data["GEOID"]).empty?
-      if data["tract_polygons"].start_with?('POLYGON')
-        geo = ActiveRecord::Base.connection.execute("SELECT ST_PolygonFromText('#{data['tract_polygons']}')").first[0]
-      elsif data["tract_polygons"].start_with?('MULTIPOLYGON')
-        geo = ActiveRecord::Base.connection.execute("SELECT ST_MultiPolygonFromText('#{data['tract_polygons']}')").first[0]
-      else
-        raise "invalid polygon"
-      end
-
-      Boundaries.create(boundary_type: 'census_tract', boundary_id: data["GEOID"], geometry: geo)
-
-      # increment the count
-      add_count += 1
-    end
   }
 
   puts "Added #{add_count} census tracts."

--- a/lib/tasks/census_tract_boundaries.rake
+++ b/lib/tasks/census_tract_boundaries.rake
@@ -11,7 +11,7 @@ task :populate_census_tracts => [:environment] do
 
   # read in the JSON line by line
   IO.foreach("/suyc/data/cb_2016_us_census_tracts.json") { |line|
-    
+
     # parse the line
     data = JSON.parse(line)
 
@@ -21,24 +21,40 @@ task :populate_census_tracts => [:environment] do
     # if the zip code doesn't include parts of Lane county, ignore it
     #next if !(data["COUNTYFP"].include? "39")
 
-    # if it's already in CensusBoundary, ignore it
-    next if CensusBoundary.where(geo_id: data["GEOID"]).present?
+    # if not in CensusBoundaries, add it
+    if CensusBoundary.where(geo_id: data["GEOID"]).empty?
+      geom_type = "Polygon"
+      polygon = GeoRuby::SimpleFeatures::Polygon.from_ewkt(data["tract_polygons"])
+      if data["tract_polygons"].start_with?('MULTIPOLYGON')
+        geom_type = "MultiPolygon"
+        polygon = GeoRuby::SimpleFeatures::MultiPolygon.from_ewkt(data["tract_polygons"])
+      end
 
-    geom_type = "Polygon"
-    polygon = GeoRuby::SimpleFeatures::Polygon.from_ewkt(data["tract_polygons"])
-    if data["tract_polygons"].start_with?('MULTIPOLYGON')
-      geom_type = "MultiPolygon"
-      polygon = GeoRuby::SimpleFeatures::MultiPolygon.from_ewkt(data["tract_polygons"])
+      # otherwise, create a new record
+      CensusBoundary.create(name: data["GEOID"], geo_id: data["GEOID"], geom_type: geom_type,
+        bounds: polygon.to_coordinates())
+
+      # increment the count
+      add_count += 1
     end
 
-    # otherwise, create a new record
-    CensusBoundary.create(name: data["GEOID"], geo_id: data["GEOID"], geom_type: geom_type,
-      bounds: polygon.to_coordinates())
+    # if not in Boundaries, add it
+    if Boundaries.where(boundary_type: 'census_tract', boundary_id: data["GEOID"]).empty?
+      if data["tract_polygons"].start_with?('POLYGON')
+        geo = ActiveRecord::Base.connection.execute("SELECT ST_PolygonFromText('#{data['tract_polygons']}')").first[0]
+      elsif data["tract_polygons"].start_with?('MULTIPOLYGON')
+        geo = ActiveRecord::Base.connection.execute("SELECT ST_MultiPolygonFromText('#{data['tract_polygons']}')").first[0]
+      else
+        raise "invalid polygon"
+      end
 
-    # increment the count
-    add_count += 1
+      Boundaries.create(boundary_type: 'census_tract', boundary_id: data["GEOID"], geometry: geo)
+
+      # increment the count
+      add_count += 1
+    end
   }
 
   puts "Added #{add_count} census tracts."
-  
+
 end

--- a/lib/tasks/create_zip_boundaries.rake
+++ b/lib/tasks/create_zip_boundaries.rake
@@ -39,19 +39,6 @@ task :populate_zip_boundaries => [:environment] do
       # increment the count
       add_count += 1
     end
-
-    # if not in Boundaries, add it
-    if Boundaries.where(boundary_type: 'zip_code', boundary_id: data["zip_code"]).empty?
-      if data["zcta_geom"].start_with?('POLYGON')
-        geo = ActiveRecord::Base.connection.execute("SELECT ST_PolygonFromText('#{data['zcta_geom']}')").first[0]
-      elsif data["zcta_geom"].start_with?('MULTIPOLYGON')
-        geo = ActiveRecord::Base.connection.execute("SELECT ST_MultiPolygonFromText('#{data['zcta_geom']}')").first[0]
-      else
-        raise "invalid polygon"
-      end
-
-      Boundaries.create(boundary_type: 'zip_code', boundary_id: data["zip_code"], geometry: geo)
-    end
   }
 
   puts "Added #{add_count} zip codes."

--- a/lib/tasks/populate_boundaries.rake
+++ b/lib/tasks/populate_boundaries.rake
@@ -54,6 +54,11 @@ task :populate_boundaries => [:environment] do
 
   types.each {|type, details|
     details[:files].each { | jsonFile |
+      puts "Processing #{jsonFile}"
+      STDOUT.flush
+
+      process_count = 0
+
       IO.foreach("/suyc/data/#{jsonFile}") { |line|
         # parse the line
         parser = GeoRuby::GeoJSONParser.new
@@ -80,7 +85,22 @@ task :populate_boundaries => [:environment] do
           # increment the count
           add_count += 1
         end
+
+        process_count += 1
+
+        if process_count % 1000 == 0
+          print "*"
+          STDOUT.flush
+        end
+
+        if process_count % 10000 == 0
+          print "\n"
+          STDOUT.flush
+        end
       }
+
+      print "\n"
+      STDOUT.flush
     }
   }
 
@@ -89,7 +109,9 @@ task :populate_boundaries => [:environment] do
 end
 
 task :populate_missing_boundaries => [:environment] do
-  puts 'Populating boundaries'
+  puts 'Populating missing boundaries'
+
+  count = 0
 
   clause = "region IS NULL OR county IS NULL OR zip_code IS NULL OR "\
     " census_code IS NULL OR census_block IS NULL"
@@ -97,5 +119,18 @@ task :populate_missing_boundaries => [:environment] do
     batch.each do |submission|
       submission.populate_boundaries
     end
+
+    count += 1
+
+    print "*"
+    STDOUT.flush
+
+    if count % 10 == 0
+      print "\n"
+      STDOUT.flush
+    end
   end
+
+  print "\n"
+  STDOUT.flush
 end

--- a/lib/tasks/populate_boundaries.rake
+++ b/lib/tasks/populate_boundaries.rake
@@ -1,0 +1,63 @@
+require 'mechanize'
+require 'json'
+require 'rake'
+require 'georuby'
+require 'geo_ruby/ewk'
+
+types = {
+  :state => [],
+  :county => [],
+  :zip_code => [],
+  :census_tract => [],
+  :census_block => [
+    "tl_2018_16_tabblock10.json",
+    "tl_2018_41_tabblock10.json",
+    "tl_2018_53_tabblock10.json",
+  ]
+}
+
+task :populate_boundaries => [:environment] do
+  puts 'Populating boundaries'
+
+  # keep track of the number of zip codes added to ZipBoundary
+  add_count = 0
+
+  types.each {|type, files|
+    files.each { | jsonFile |
+      IO.foreach("/suyc/data/#{jsonFile}") { |line|
+        # parse the line
+        parser = GeoRuby::GeoJSONParser.new
+        feature = parser.parse(line)
+
+        id = feature.properties["GEOID10"]
+        geometry = feature.geometry.as_wkt()
+
+        # if not in Boundaries, add it
+        if Boundaries.where(boundary_type: type, boundary_id: id).empty?
+          if geometry.start_with?('POLYGON')
+            geometry = ActiveRecord::Base.connection.execute("SELECT ST_PolygonFromText('#{geometry}')").first[0]
+          elsif geometry.start_with?('MULTIPOLYGON')
+            geometry = ActiveRecord::Base.connection.execute("SELECT ST_MultiPolygonFromText('#{geometry}')").first[0]
+          else
+            raise "invalid polygon"
+          end
+
+          Boundaries.create(boundary_type: type, boundary_id:id, geometry: geometry)
+
+          # increment the count
+          add_count += 1
+        end
+      }
+    }
+  }
+
+  puts "Added #{add_count} boundaries"
+
+end
+
+task :populate_missing_boundaries => [:environment] do
+  puts 'Populating boundaries'
+
+  Submissions.unscoped.where('zip_code IS NULL OR census_code IS NULL OR census_block IS NULL')
+
+end

--- a/lib/tasks/stats_cache.rake
+++ b/lib/tasks/stats_cache.rake
@@ -21,8 +21,8 @@ task :update_stats_cache => [:environment] do
 
     all_uploads = Submission.get_zip_code_for_stats_cache(stats_id, "upload")
     all_downloads = Submission.get_zip_code_for_stats_cache(stats_id, "download")
-    sua_uploads = Submission.get_zip_code_for_stats_cache(stats_id, "upload").not_from_mlab
-    sua_downloads = Submission.get_zip_code_for_stats_cache(stats_id, "download").not_from_mlab
+    sua_uploads = all_uploads.not_from_mlab
+    sua_downloads = all_downloads.not_from_mlab
 
     upsertStats('zip_code', stats_id, 'all', '1970-01-01', all_uploads, all_downloads, sua_uploads, sua_downloads)
 
@@ -37,7 +37,7 @@ task :update_stats_cache => [:environment] do
 
       upsertStats('zip_code', stats_id, 'month', range_start.strftime("%Y-%m-%d"), all_uploads_month,
         all_downloads_month, sua_uploads_month, sua_downloads_month)
-    end      
+    end
   end
 
   puts "Census Tracts - #{Time.now}"
@@ -54,8 +54,8 @@ task :update_stats_cache => [:environment] do
 
     all_uploads = Submission.get_census_tract_for_stats_cache(stats_id, "upload")
     all_downloads = Submission.get_census_tract_for_stats_cache(stats_id, "download")
-    sua_uploads = Submission.get_census_tract_for_stats_cache(stats_id, "upload").not_from_mlab
-    sua_downloads = Submission.get_census_tract_for_stats_cache(stats_id, "download").not_from_mlab
+    sua_uploads = all_uploads.not_from_mlab
+    sua_downloads = all_downloads.not_from_mlab
 
     upsertStats('census_tract', stats_id, 'all', '1970-01-01', all_uploads, all_downloads, sua_uploads, sua_downloads)
 
@@ -70,7 +70,7 @@ task :update_stats_cache => [:environment] do
 
       upsertStats('census_tract', stats_id, 'month', range_start.strftime("%Y-%m-%d"), all_uploads_month,
         all_downloads_month, sua_uploads_month, sua_downloads_month)
-    end    
+    end
   end
 
   puts "Providers - #{Time.now}"
@@ -87,8 +87,8 @@ task :update_stats_cache => [:environment] do
 
     all_uploads = Submission.get_provider_for_stats_cache(stats_id, "upload")
     all_downloads = Submission.get_provider_for_stats_cache(stats_id, "download")
-    sua_uploads = Submission.get_provider_for_stats_cache(stats_id, "upload").not_from_mlab
-    sua_downloads = Submission.get_provider_for_stats_cache(stats_id, "download").not_from_mlab
+    sua_uploads = all_uploads.not_from_mlab
+    sua_downloads = all_downloads.not_from_mlab
 
     upsertStats('provider', stats_id, 'all', '1970-01-01', all_uploads, all_downloads, sua_uploads, sua_downloads)
 
@@ -103,7 +103,7 @@ task :update_stats_cache => [:environment] do
 
       upsertStats('provider', stats_id, 'month', range_start.strftime("%Y-%m-%d"), all_uploads_month,
         all_downloads_month, sua_uploads_month, sua_downloads_month)
-    end   
+    end
   end
 
   puts "Finished update stats cache. #{Time.now}"
@@ -117,7 +117,7 @@ def upsertStats(stats_type, stats_id, date_type, date_value, all_uploads, all_do
     date_type: date_type,
     date_value: date_value,
   }
-  
+
   record = StatsCache.where(key).first
   if record.nil?
     record = StatsCache.new(key)
@@ -127,10 +127,10 @@ def upsertStats(stats_type, stats_id, date_type, date_value, all_uploads, all_do
   all_downloads = all_downloads.select("actual_down_speed")
   all_downloads_array = all_downloads.map(&:"actual_down_speed").compact
   all_count_download = all_downloads_array.length
-  if all_count_download > 0 
+  if all_count_download > 0
     # calculate basic stats
     all_avg_download, all_median_download, all_fast_download = calculate_basic_stats(all_downloads_array)
-    
+
     # breakdown (bucket counts)
     all_breakdown_download = calculate_speed_breakdown(all_downloads_array)
 
@@ -161,7 +161,7 @@ def upsertStats(stats_type, stats_id, date_type, date_value, all_uploads, all_do
   if all_count_upload > 0
     # calculate basic stats
     all_avg_upload, all_median_upload, all_fast_upload = calculate_basic_stats(all_uploads_array)
-    
+
     # breakdown (bucket counts)
     all_breakdown_upload =  calculate_speed_breakdown(all_uploads_array)
 
@@ -177,7 +177,7 @@ def upsertStats(stats_type, stats_id, date_type, date_value, all_uploads, all_do
   sua_uploads = sua_uploads.select("actual_upload_speed")
   sua_uploads_array = sua_uploads.map(&:"actual_upload_speed").compact
   sua_count_uploads = sua_uploads_array.length
-  if sua_count_uploads > 0 
+  if sua_count_uploads > 0
      # calculate basic stats
      sua_avg_upload, sua_median_upload, sua_fast_upload = calculate_basic_stats(sua_uploads_array)
   end
@@ -199,13 +199,13 @@ def upsertStats(stats_type, stats_id, date_type, date_value, all_uploads, all_do
     download_0_5: all_breakdown_download.nil? ? 0 : all_breakdown_download[0],
     download_6_10: all_breakdown_download.nil? ? 0 : all_breakdown_download[1],
     download_11_20: all_breakdown_download.nil? ? 0 : all_breakdown_download[2],
-    download_21_40: all_breakdown_download.nil? ? 0 : all_breakdown_download[3], 
-    download_40_60: all_breakdown_download.nil? ? 0 : all_breakdown_download[4], 
-    download_61_80: all_breakdown_download.nil? ? 0 : all_breakdown_download[5], 
+    download_21_40: all_breakdown_download.nil? ? 0 : all_breakdown_download[3],
+    download_40_60: all_breakdown_download.nil? ? 0 : all_breakdown_download[4],
+    download_61_80: all_breakdown_download.nil? ? 0 : all_breakdown_download[5],
     download_81_100: all_breakdown_download.nil? ? 0 : all_breakdown_download[6],
-    download_101_250: all_breakdown_download.nil? ? 0 : all_breakdown_download[7], 
-    download_251_500: all_breakdown_download.nil? ? 0 : all_breakdown_download[8], 
-    download_500_1000: all_breakdown_download.nil? ? 0 : all_breakdown_download[9], 
+    download_101_250: all_breakdown_download.nil? ? 0 : all_breakdown_download[7],
+    download_251_500: all_breakdown_download.nil? ? 0 : all_breakdown_download[8],
+    download_500_1000: all_breakdown_download.nil? ? 0 : all_breakdown_download[9],
     download_1001: all_breakdown_download.nil? ? 0 : all_breakdown_download[10],
 
     download_less_than_5: all_download_less_than_5.nil? ? 0 : all_download_less_than_5,
@@ -226,13 +226,13 @@ def upsertStats(stats_type, stats_id, date_type, date_value, all_uploads, all_do
     upload_0_5: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[0],
     upload_6_10: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[1],
     upload_11_20: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[2],
-    upload_21_40: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[3], 
-    upload_40_60: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[4], 
-    upload_61_80: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[5], 
+    upload_21_40: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[3],
+    upload_40_60: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[4],
+    upload_61_80: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[5],
     upload_81_100: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[6],
-    upload_101_250: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[7], 
-    upload_251_500: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[8], 
-    upload_500_1000: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[9], 
+    upload_101_250: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[7],
+    upload_251_500: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[8],
+    upload_500_1000: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[9],
     upload_1001: all_breakdown_upload.nil? ? 0 : all_breakdown_upload[10],
 
     upload_less_than_5: all_upload_less_than_5.nil? ? 0 : all_upload_less_than_5,

--- a/update_data.sh
+++ b/update_data.sh
@@ -7,6 +7,7 @@ rake populate_zip_boundaries
 rake import_mlab_submissions
 rake update_pending_census_codes
 rake populate_missing_isps
+rake populate_missing_boundaries
 rake update_providers_statistics
 rake update_stats_cache
 echo "Data procesing complete"

--- a/update_data.sh
+++ b/update_data.sh
@@ -5,9 +5,8 @@ rake populate_boundaries
 rake populate_census_tracts
 rake populate_zip_boundaries
 rake import_mlab_submissions
-rake update_pending_census_codes
-rake populate_missing_isps
 rake populate_missing_boundaries
+rake populate_missing_isps
 rake update_providers_statistics
 rake update_stats_cache
 echo "Data procesing complete"

--- a/update_data.sh
+++ b/update_data.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 echo "Data procesing starting"
+rake populate_boundaries
 rake populate_census_tracts
 rake populate_zip_boundaries
 rake import_mlab_submissions


### PR DESCRIPTION
Major changes:
* Introduces generic boundaries table/model
* Submissions now fill out the region, county, ZIP, Census Tract, and Census Block from boundaries table at the time of submissions creation
* Added tasks for loading boundaries and backfilling submisisons
* Set development log level to info
* Removed references to submissions.census_stats, will remove DB column later
* Simplifies some data-related tasks (single SQL dump)

This PR depends on https://github.com/Hack4Eugene/speedupamerica-migrator/pull/10 and most not be merged before that other PR is merged and given time to deploy.