### PR TITLE
Change Megabytes to Megabits

### DIFF
--- a/app/views/home/_form_step_2a.html.erb
+++ b/app/views/home/_form_step_2a.html.erb
@@ -40,7 +40,7 @@
       <div class='row'>
         <%= f.label :provider_down_speed, class: 'col-md-6' do %>
           What is your advertised download speed?
-          <span rel='tooltip' class='glyphicon glyphicon-info-sign info-color' title='Your "advertised download speed" is how many Megabytes Per Second (Mbps, a measure of internet speed), you have agreed to with your internet provider.'></span>
+          <span rel='tooltip' class='glyphicon glyphicon-info-sign info-color' title='Your "advertised download speed" is how many Megabits Per Second (Mbps, a measure of internet speed), you have agreed to with your internet provider.'></span>
         <% end %>
 
         <div class='col-md-4 restricted-field text-left'>


### PR DESCRIPTION
Fixes #198 
I also looked for all instances of "Mbps" and they all are correctly cased.