### PR TITLE
Adding James Coulter to contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Committers:
 * Kirk Hutchison
 * Bishop Lafer
 * Cory Borman
+* James Coulter
 
 Technical Committee:
 


### PR DESCRIPTION
James has made several contributions, including solving a pain point that blocked Windows 10 Home users from onboarding, and I believe his effort and work has earned him a spot on the contributor list.

* https://github.com/Hack4Eugene/SpeedUpAmerica/wiki/Docker-for-Windows/_history
* https://github.com/Hack4Eugene/SpeedUpAmerica/pulls?q=is%3Apr+is%3Aclosed+author%3AJCoulter85

This PR should only be approved and merged with 2 additional 👍 from TC members.