### PR TITLE
Set `client_application` to "SpeedUpAmerica"

### DIFF
--- a/vendor/assets/javascripts/ndt.js
+++ b/vendor/assets/javascripts/ndt.js
@@ -440,9 +440,11 @@ NDTjs.prototype.ndtMetaTest = function (ndtSocket) {
     }
     if (state === 'WAIT_FOR_TEST_START' && messageType === that.TEST_START) {
       that.callbacks.onstatechange('running_meta', that.results);
-      // Send one piece of meta data and then an empty meta data packet
-      ndtSocket.send(that.makeNdtMessage(that.TEST_MSG,
-                                         'client.os.name:NDTjs'));
+      // Send meta data and then an empty meta data packet
+      ndtSocket.send(that.makeNdtMessage(
+        that.TEST_MSG,
+        'client.application:SpeedUpAmerica'
+      ));
       ndtSocket.send(that.makeNdtMessage(that.TEST_MSG, ''));
       state = 'WAIT_FOR_TEST_FINALIZE';
       return false;


### PR DESCRIPTION
The metadata we send to M-Lab now sets the value for `client_application`. It no longer sets `client_os`. `client_os` was previously set to `'NDTjs'` in the provided code, which is surprising since that field is intended to represent the client's operating system.

Note that I've set the value to "SpeedUpAmerica" (with capitals).

Closes #178 

There are other optional pieces of metadata that we could set if we wanted to. See the fields marked "optional" in [the M-Lab docs](https://www.measurementlab.net/data/docs/bq/schema/ndt/#ndt-schema---measurement-labndtrecommended). I don't think any of them are necessary, since we collect the data separately, but here are a few interesting ones:

* `client_browser`
* `client_os` (And actually set it to the client's OS?)
* `client_version` (Version our client? Distinguish between dev/test and prod?)

Note that we would need to set these in the *client*-side code, since they're sent as part of the speed test.