### PR TITLE
Census Blocks behind QS flag

### DIFF
--- a/app/assets/javascripts/mapboxgl.coffee
+++ b/app/assets/javascripts/mapboxgl.coffee
@@ -1,19 +1,31 @@
 popup = null
-census_layer = {
-  url: 'mapbox://mattsayre.1pdu0bcw',
-  source: 'census-tracts',
-  name: 'tracts',
-  data_id: 'GEOID'
-}
-zip_layer = {
-  url: 'mapbox://mattsayre.857dv4qz',
-  source: 'zip-codes',
-  name: 'cb_2018_us_zcta510_500k',
-  data_id: 'ZCTA5CE10'
+
+layers = {
+  census_code: {
+    url: 'mapbox://mattsayre.1pdu0bcw',
+    source: 'census-tracts',
+    name: 'tracts',
+    data_id: 'GEOID',
+    label: 'Census Tact'
+  },
+  census_block: {
+    url: 'mapbox://mattsayre.3cpval7a',
+    source: 'census-blocks',
+    name: 'blocks',
+    data_id: 'GEOID10',
+    label: 'Census Block'
+  },
+  zip_code: {
+    url: 'mapbox://mattsayre.857dv4qz',
+    source: 'zip-codes',
+    name: 'cb_2018_us_zcta510_500k',
+    data_id: 'ZCTA5CE10'
+    label: 'ZIP Code'
+  }
 }
 
 window.initialize_mapboxgl = (elmID) ->
-  mapboxgl.accessToken = MAPBOX_API_KEY;
+  mapboxgl.accessToken = MAPBOX_API_KEY
   maxZoom = 14
 
   map = new mapboxgl.Map({
@@ -25,10 +37,10 @@ window.initialize_mapboxgl = (elmID) ->
   })
 
   # disable map rotation using right click + drag
-  map.dragRotate.disable();
+  map.dragRotate.disable()
 
   # disable map rotation using touch rotation gesture
-  map.touchZoomRotate.disableRotation();
+  map.touchZoomRotate.disableRotation()
 
   # Add zoom and rotation controls to the map.
   map.addControl(new mapboxgl.NavigationControl({showCompass: false}))
@@ -46,32 +58,38 @@ clearMap = (map) ->
   if popup
     popup.remove()
 
-  for layer in [census_layer, zip_layer]
+  for id, layer of layers
     if map.getLayer(layer.name)
       map.removeLayer(layer.name)
     if map.getSource(layer.source)
       map.removeSource(layer.source)
 
-addLayer = (map, layer, data, test_type, layer_type) ->
+addLayer = (map, group_by, data, test_type) ->
+  layer = layers[group_by]
+  if layer == undefined
+    throw new Error('unknown layer: ' + group_by)
+
   map.addSource(layer.source, {
     type: "vector",
     url: layer.url
-  });
+  })
+
 
   colorExpression = ["match", ["get", layer.data_id]]
   opacityExpression = ["match", ["get", layer.data_id]]
   lineExpression = ["match", ["get", layer.data_id]]
+
   # Calculate color for each state based on the unemployment rate
   data.forEach((row) ->
     colorExpression.push(row["id"], row["color"])
     opacityExpression.push(row["id"], row["fillOpacity"])
     lineExpression.push(row["id"], "#000000")
   )
-  # Last value is the default, used where there is no data
-  colorExpression.push("rgba(0, 0, 0, 0)");
-  opacityExpression.push(0.0)
-  lineExpression.push("rgba(0, 0, 0, 0)");
 
+  # Last value is the default, used where there is no data
+  colorExpression.push("rgba(0, 0, 0, 0)")
+  opacityExpression.push(0.0)
+  lineExpression.push("rgba(0, 0, 0, 0)")
 
   # Add layer from the vector tile source with data-driven style
   map.addLayer({
@@ -88,11 +106,11 @@ addLayer = (map, layer, data, test_type, layer_type) ->
   })
 
   map.on('mouseenter',  layer.name, () ->
-    map.getCanvas().style.cursor = 'pointer';
+    map.getCanvas().style.cursor = 'pointer'
   )
 
   map.on('mouseleave', layer.name,  () ->
-    map.getCanvas().style.cursor = '';
+    map.getCanvas().style.cursor = ''
   )
 
   map.on('click',  layer.name, (e) ->
@@ -110,8 +128,8 @@ addLayer = (map, layer, data, test_type, layer_type) ->
         stats = datum
         break
 
-    content = "<h4>#{layer_type}: " + stats.id + "</h4>" +
-      "<p>Tests in this #{layer_type}: <strong>" + stats.all_count + '</strong></p>' +
+    content = "<h4>#{layer.label}: " + stats.id + "</h4>" +
+      "<p>Tests in this #{layer.label}: <strong>" + stats.all_count + '</strong></p>' +
       "<p>Median #{test_type[0].toUpperCase() + test_type[1..-1]} Speed: <strong>" +
         stats.all_median + " Mbps</strong></p>" +
       "<p>Fastest #{test_type[0].toUpperCase() + test_type[1..-1]} Speed: <strong>" +
@@ -126,7 +144,7 @@ addLayer = (map, layer, data, test_type, layer_type) ->
       .addTo(map)
   )
 
-window.set_mapbox_zip_data_gl = (map, provider, group_by='zip_code', test_type='download') ->
+window.set_mapbox_groupby = (map, provider, group_by, test_type, label) ->
   loader = get_map_loader(map)
   loader.removeClass('hide')
 
@@ -141,7 +159,7 @@ window.set_mapbox_zip_data_gl = (map, provider, group_by='zip_code', test_type='
       group_by: group_by
       test_type: test_type
     success: (data) ->
-      addLayer(map, zip_layer, data.result, test_type, "Zip Code")
+      addLayer(map, group_by, data.result, test_type)
 
       loader.addClass('hide')
       disable_filters('map-filters', false)
@@ -153,35 +171,3 @@ window.set_mapbox_zip_data_gl = (map, provider, group_by='zip_code', test_type='
       Sentry.setExtra("response_status",  statusText)
       Sentry.setExtra("response_error",  errorText)
       Sentry.captureException(err)
-
-window.set_mapbox_census_data_gl = (map, provider, test_type, zip_code, census_code, type) ->
-  loader = get_map_loader(map)
-  loader.removeClass('hide')
-
-  clearMap(map)
-
-  $.ajax
-    url: '/stats/groupby'
-    type: 'POST'
-    dataType: 'json'
-    data:
-      provider: provider
-      group_by: 'census_code'
-      test_type: test_type
-      zip_code: zip_code
-      census_code: census_code
-      type: type
-    success: (data) ->
-      addLayer(map, census_layer, data.result, test_type, 'Census Tract')
-
-      loader.addClass('hide')
-      disable_filters('map-filters', false)
-    error: (request, statusText, errorText) ->
-      err = new Error("get census data failed")
-
-      Sentry.setExtra("status_code", request.status)
-      Sentry.setExtra("body",  request.responseText)
-      Sentry.setExtra("response_status",  statusText)
-      Sentry.setExtra("response_error",  errorText)
-      Sentry.captureException(err)
-

--- a/app/assets/javascripts/results.coffee
+++ b/app/assets/javascripts/results.coffee
@@ -43,7 +43,7 @@ set_multiple_selected_values = ->
 
 monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "June",
   "July", "Aug", "Sep", "Oct", "Nov", "Dec"
-];
+]
 
 apply_filters = (map) ->
   update_map = ->
@@ -56,10 +56,7 @@ apply_filters = (map) ->
 
     $('#all_results_map').removeClass('hide')
 
-    if group_by == 'zip_code'
-      set_mapbox_zip_data_gl(map, provider, group_by, test_type)
-    else if group_by == 'census_code'
-      set_mapbox_census_data_gl(map, provider, test_type, '', '', '')
+    set_mapbox_groupby(map, provider, group_by, test_type)
 
   $('#map-filters .filter').on 'change', ->
     update_all_option($(this))

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -3,6 +3,7 @@ class SubmissionsController < ApplicationController
   before_action :initialize_stats_data, only: [:show, :embeddable_view]
   before_action :set_submission, only: [:show]
   before_action :set_selected_providers, only: [:result_page]
+  before_action :set_feature_blocks, only: [:result_page]
   before_action :set_selected_providers_for_submission, only: [:show]
   before_action :set_selected_zip_codes, only: [:show]
   skip_before_action :verify_authenticity_token, only: [:embed]
@@ -24,7 +25,7 @@ class SubmissionsController < ApplicationController
     data = Submission.fetch_tileset_groupby(params)
     render json: data
   rescue StandardError => e
-    render status: 500, json: {'status': 'error', 'error': 'problem getting stats'}
+    render status: 500, json: {'status': 'error', 'error': e.message}
   end
 
   def result_page
@@ -48,13 +49,7 @@ class SubmissionsController < ApplicationController
     render json: data
   end
 
-  def isps_data
-    data = Submission.service_providers_data(params[:type], params[:categories], params[:connection_type], params[:provider])
-    render json: data
-  end
-
   def export_csv
-    # send_data Submission.to_csv(params[:date_range]), filename: "submissions - #{Time.now}.csv"
     render_csv
   end
 
@@ -133,6 +128,12 @@ class SubmissionsController < ApplicationController
         .group('p.id').order('count DESC').first(3).map(&:id)
 
       @selected_provider_ids = ids
+    end
+
+    def set_feature_blocks
+      if request.query_parameters[:feature_blocks].present?
+        @feature_blocks = true
+      end
     end
 
     def set_selected_providers

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -75,4 +75,14 @@ module SubmissionsHelper
     all_option = ['All', 'all']
     codes.map { |code| [code, code] }.unshift(all_option)
   end
+
+  def get_group_bys()
+    group_bys = Submission::MAP_FILTERS[:group_by]
+
+    if @feature_blocks == true
+      group_bys[:census_block] = 'census_block'
+    end
+
+    return group_bys
+  end
 end

--- a/app/models/census_boundary.rb
+++ b/app/models/census_boundary.rb
@@ -1,3 +1,0 @@
-class CensusBoundary < ActiveRecord::Base
-  serialize :bounds, Array
-end

--- a/app/models/service_provider.rb
+++ b/app/models/service_provider.rb
@@ -1,5 +1,0 @@
-class ServiceProvider < ActiveRecord::Base
-
-  scope :with_ipa, -> (numeric_ipa) { where 'start_ipa <= ? AND end_ipa >= ?', numeric_ipa, numeric_ipa }
-
-end

--- a/app/models/zip_boundary.rb
+++ b/app/models/zip_boundary.rb
@@ -1,3 +1,0 @@
-class ZipBoundary < ActiveRecord::Base
-  serialize :bounds, Array
-end

--- a/app/views/submissions/_filters.html.erb
+++ b/app/views/submissions/_filters.html.erb
@@ -31,7 +31,7 @@
           <p>Group By:</p>
 
           <div class='group-by-filter'>
-            <%= select_tag :group_by, options_for_select(Submission::MAP_FILTERS[:group_by].map { |k, v| [k.to_s.titleize, v] }), { disabled: true, class: 'chosen-select filter' } %>
+            <%= select_tag :group_by, options_for_select(get_group_bys.map { |k, v| [k.to_s.titleize, v] }), { disabled: true, class: 'chosen-select filter' } %>
           </div>
         </div>
       </div>

--- a/app/views/submissions/_stats_filters.html.erb
+++ b/app/views/submissions/_stats_filters.html.erb
@@ -24,7 +24,7 @@
     <div class='col-xs-12 col-sm-12 col-md-4 col-lg-4 filter-container' id='census_selector'>
       <p>Census Tracts:</p>
 
-      <%= select_tag :census_code, options_for_select(get_list_values(Submission::CENSUS_CODES)), { disabled: true, class: 'chosen-select filter', multiple: true } %>
+      <%= select_tag :census_code, options_for_select(get_list_values(Submission::CENSUS_TRACTS)), { disabled: true, class: 'chosen-select filter', multiple: true } %>
       <%= hidden_field_tag :selected_census_code %>
     </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,6 @@ Rails.application.routes.draw do
   get 'result/:test_id', to: 'submissions#show', as: :submission
   post 'stats/groupby', to: 'submissions#tileset_groupby', defaults: { format: :json }
   get 'speed_data', to: 'submissions#speed_data'
-  get 'isps_data', to: 'submissions#isps_data'
   get 'internet-stats', to: redirect('all-results')
   get 'embeddable_view', to: 'submissions#embeddable_view'
   get 'embed', to: 'submissions#embed', defaults: { format: :js }, constraints: { format: :js }


### PR DESCRIPTION
The ability to view Lane County data at the Census Block level has been requested. This PR adds `Census Block` to the map's group by list when `feature_blocks=1` is present in the `all-results` page's query string. 

* Moved layers defined in JS to a map/dictionary
* Removed a lot of duplicate and unused logic/functions
* Made adding layers to the map generic, make adding more group bys easier
* Made some logic in the Submission model generic, making adding group bys easier
* Removed semi-colons from Coffeescript
* Added enabled flag to boundaries, removing the need for some tables/models (zip_boundary, census_boundary)
* Removed `service_providers` models, not used anymore
* Updated `stats_cache` task to populate stats cache based on enabled boundaries

Requires https://github.com/Hack4Eugene/speedupamerica-migrator/pull/12/files