### PR TITLE
Fix missing require for geojson

### DIFF
--- a/lib/tasks/populate_boundaries.rake
+++ b/lib/tasks/populate_boundaries.rake
@@ -3,6 +3,7 @@ require 'json'
 require 'rake'
 require 'georuby'
 require 'geo_ruby/ewk'
+require 'geo_ruby/geojson'
 
 types = {
   :region => {


### PR DESCRIPTION
Fixed an error in the boundary loading rake task:
```
NameError: uninitialized constant GeoRuby::GeoJSONParser
/suyc/lib/tasks/populate_boundaries.rake:64:in `block (4 levels) in <top (required)>'
/suyc/lib/tasks/populate_boundaries.rake:62:in `foreach'
/suyc/lib/tasks/populate_boundaries.rake:62:in `block (3 levels) in <top (required)>'
/suyc/lib/tasks/populate_boundaries.rake:56:in `each'
/suyc/lib/tasks/populate_boundaries.rake:56:in `block (2 levels) in <top (required)>'
/suyc/lib/tasks/populate_boundaries.rake:55:in `each'
/suyc/lib/tasks/populate_boundaries.rake:55:in `block in <top (required)>'
```