### PR TITLE
Remove ISP from map filters until we can fix OOM crash

### DIFF
--- a/app/views/submissions/_filters.html.erb
+++ b/app/views/submissions/_filters.html.erb
@@ -12,6 +12,7 @@
   </ul>
 
   <div class="service-provider-section">
+    <!-- Removing until we solve OOM issue
     <div class='row'>
       <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12'>
         <div class='provider'>
@@ -24,6 +25,7 @@
         </div>
       </div>
     </div>
+    -->
 
     <div class='row'>
       <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12'>


### PR DESCRIPTION
Setting the map ISP filter to a large ISP like Comcast or CentruryLink crashes/timesout the frontend. This PR removes the dropdown until we can solve the issue. This is a data size issue.