### PR TITLE
Standing down as a TC member

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Committers:
 * Bishop Lafer
 * Cory Borman
 * James Coulter
+* Ryan Olds
 
 Technical Committee:
 

--- a/README.md
+++ b/README.md
@@ -292,4 +292,3 @@ Technical Committee:
 * Chris Ritzo
 * Chris Sjoblom
 * Antonio Ortega
-* Ryan Olds


### PR DESCRIPTION
I need to reallocate the time I spend on this project to personal and technical growth. I wish the project luck. I will continue to be around if their are questions or problems; I just won't be contributing code or significant time to the project.

I've made sure that Matt Sayre (and I think Deigo) have SSH keys to the EC2 instances. There are some Dropbox Paper documents on my personal Dropbox account that should be moved to the Wiki. I don't care if the documents remain there, I have no plans to deprecate my Dropbox account.