### PR TITLE
SubmissionsImporter - fixed issue with 'Time to string' conversion

### DIFF
--- a/app/classes/submissions_importer.rb
+++ b/app/classes/submissions_importer.rb
@@ -144,7 +144,7 @@ class SubmissionsImporter
 
     data.each do |row|
       count = Submission.unscoped.where('test_date = ? AND ip_address = ? AND test_type = ?',
-        Date.parse(row[:UTC_date_time]), row[:client_ip], test_type).count
+        row[:UTC_date_time], row[:client_ip], test_type).count
       next if count > 0
 
       submission = Submission.new


### PR DESCRIPTION
The recent MLab Query update automatically converts UTC_date_time to a String object.
This results in the following error:
`TypeError: no implicit conversion of Time into String`

Here, we remove the conversion and the issue is fixed and the importer works.