### PR TITLE
Update messaging for failed geolocation lookup

### DIFF
--- a/app/assets/javascripts/home.coffee
+++ b/app/assets/javascripts/home.coffee
@@ -34,7 +34,7 @@ block_callback = (err) ->
 
   if err.code == err.POSITION_UNAVAILABLE && is_safari()
     $('#error-position_unavailable').modal('show')
-  else 
+  else
     $('#error-geolocation').modal('show')
 
   Sentry.setExtra("error_code", err.code)
@@ -45,7 +45,6 @@ is_safari = ->
   ua = navigator.userAgent.toLowerCase()
   return (ua.indexOf('safari') != -1) && (ua.indexOf('chrome') == -1)
 
-  
 get_location = ->
   if navigator.geolocation
     location_start()
@@ -248,7 +247,6 @@ $ ->
 
     if $('#location_disabled').prop('checked')
       show_step_one()
-
 
   $(".checkboxes-container input[name='submission[testing_for]']").on 'change', ->
     $(".checkboxes-container input[name='submission[testing_for]']").each ->

--- a/app/views/home/_error_geolocation.html.erb
+++ b/app/views/home/_error_geolocation.html.erb
@@ -11,14 +11,18 @@
           <div class='col-md-12'>
             <h5 class='text-center'>
               <b>Safari Browser:</b> Please turn on WiFi and enable
-              <%= link_to ' Location Services.', 'https://support.apple.com/en-us/HT204690', target: '_blank', rel: 'noopener' %>
+              <%= link_to 'Location Services', 'https://support.apple.com/en-us/HT204690', target: '_blank', rel: 'noopener' %>.
+            </h5>
+            <h5 class='text-center'>
+              <b>Firefox Browser:</b> Please consider updating your browser's
+              <%= link_to 'Location Service', 'https://wiki.archlinux.org/index.php/Firefox#Geolocation_does_not_work', target: '_blank', rel: 'noopener' %>.
             </h5>
           </div>
         </div>
         <div class='row'>
           <div class='col-md-12'>
             <h5 class='text-center'>
-              In order to use the Speed Test, please allow location services. This is to ensure that all speed tests are submitted from the zip-code area only.
+              In order to use your browser's location for the Speed Test, please allow location services. This is to ensure that all speed tests are submitted from the zip-code area only.
             </h5>
           </div>
         </div>

--- a/app/views/home/_error_position_unavailable.html.erb
+++ b/app/views/home/_error_position_unavailable.html.erb
@@ -10,8 +10,8 @@
       <div class='row'>
           <div class='col-md-12'>
             <h5 class='text-center'>
-              <b>Safari Browser:</b> Please Turn on WiFi and Location Services.
-              <%= link_to ' Location Services.', 'https://support.apple.com/en-us/HT204690', target: '_blank', rel: 'noopener' %>
+              <b>Safari Browser:</b> Please Turn on WiFi and
+              <%= link_to 'Location Services', 'https://support.apple.com/en-us/HT204690', target: '_blank', rel: 'noopener' %>.
             </h5>
           </div>
         </div>


### PR DESCRIPTION
Firefox's geolocation hasn't been working, but it's not actually an issue with the browser itself. The issue is that the Google API it depends on to look up the geolocation is denying the request. There appears to be a repeating issue over the years of API keys used by Firefox (and Chromium) hitting service limits, and fixes have generally been slow.

When I attempted a geolocation lookup in Firefox, the error message returned by the browser API was the incredibly unhelpful "Unknown error acquiring position".

A couple bugzilla links related to this issue, if you're curious:
https://bugzilla.mozilla.org/show_bug.cgi?id=1232995
https://bugzilla.mozilla.org/show_bug.cgi?id=1610306

### Solution:

Because we can't directly fix this issue on our users' behalf, the best we can offer is some info on changing their own browser configuration to use a different location service, which is what this PR does. Specifically, I provide a link to [this page](https://wiki.archlinux.org/index.php/Firefox#Geolocation_does_not_work) which gives some terse instructions for making the change. I wish there was a friendlier page with instructions to link to, but everything else I found was in the comments of a bug report, which I expect would be even harder to parse for the average user.

Essentially, the instructions are to go to `about:config` in Firefox's address bar, search for `geo.provider.network.url`, and change its value to `https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%` in order to use Mozilla's location service instead of Google's. Folks have said, in some issues I found, that Mozilla's location service is a little less accurate. It's still fairly close, though, and it was just a few blocks off from my own location in the test I did. By comparison, an IP address lookup I did returned an entirely different city an hour's drive away.

*Side note: Since geolocation can break from time to time, I wonder if an issue similar to this one is why SpeedUpAmerica's initial implementation looked up location by IP. I still think we're going a better direction now, since IP lookups are so inaccurate and we also offer the option for the user to directly enter their address.*

Closes #255