### PR TITLE
Added 'Census Block' column to CSV export

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -262,14 +262,14 @@ class Submission < ActiveRecord::Base
   end
 
   CSV_COLUMNS = [
-    'Response #', 'Source', 'Date', 'How Are You Testing', 'Zip', 'Census Tract',
+    'Response #', 'Source', 'Date', 'How Are You Testing', 'Zip', 'Census Tract', 'Census Block',
     'Provider', 'How are you connected', 'Price Per Month', 'Advertised Download Speed',
     'Satisfaction Rating', 'Download Speed', 'Upload Speed', 'Advertised Price Per Mbps',
     'Actual Price Per Mbps', 'Ping'
   ]
 
   CSV_KEYS = [
-    :id, :source, :date, :testing_for, :zip_code, :census_code, :provider, :connected_with,
+    :id, :source, :date, :testing_for, :zip_code, :census_code, :census_block, :provider, :connected_with,
     :monthly_price, :provider_down_speed, :rating,:actual_down_speed, :actual_upload_speed,
     :provider_price, :actual_price, :ping
   ]
@@ -282,7 +282,7 @@ class Submission < ActiveRecord::Base
 
   def to_csv_row
     CSV::Row.new(CSV_KEYS, [id, source, test_date.strftime('%B %d, %Y'), Submission::testing_for_mapping(testing_for),
-      zip_code, census_code, provider, connected_with, monthly_price, provider_down_speed, rating, actual_down_speed,
+      zip_code, census_code, census_block, provider, connected_with, monthly_price, provider_down_speed, rating, actual_down_speed,
       actual_upload_speed, provider_price, actual_price, ping])
   end
 


### PR DESCRIPTION
This pull requests adds the existing data column `census_block` to the exported CSV.

We will be able to confirm this once merged to production when the CVS Export automatically runs and is saved to the S3 bucket.

**Testing:**
Please confirm that the Census Block column appears in the CSV Export.