### PR TITLE
Revert "Fixes 265"

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -7,8 +7,8 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - aws --version
+      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
       - REPOSITORY_URI=238241637211.dkr.ecr.us-west-2.amazonaws.com/speedupamerica
-      - aws ecr get-login-password | docker login --username AWS --password-stdin $REPOSITORY_URI
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:


### PR DESCRIPTION
Reverts Hack4Eugene/SpeedUpAmerica#266.

Not a valid solution. 
Reverting change because the current setup is valid for AWS CLI V1. 

Requires upgrading AWS CLI to 1.18.185 to use get-login-password.
[AWS Documentation](https://docs.aws.amazon.com/cli/latest/reference/ecr/get-login-password.html)

Will have to keep going with SSHing into AWS EC2 Instance and running Docker Login commands.