### PR TITLE
Delete GitHub link from homepage -- issue 250

### DIFF
--- a/app/views/home/_form_step_1.html.erb
+++ b/app/views/home/_form_step_1.html.erb
@@ -20,9 +20,4 @@
   <%= button_tag 'Let\'s do this!', type: 'button', id: 'testing_for_button', disabled: true, class: 'primaryBtn' %>
 
   <%= render 'bottom_description' %>
-
-  <div class='text-center find-more-div'>
-    Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
-  </div>
 </div>

--- a/app/views/home/_form_step_2a.html.erb
+++ b/app/views/home/_form_step_2a.html.erb
@@ -77,9 +77,4 @@
   </div>
 
   <%= render 'bottom_description' %>
-
-  <div class='text-center find-more-div'>
-    Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
-  </div>
 </div>

--- a/app/views/home/_form_step_2b.html.erb
+++ b/app/views/home/_form_step_2b.html.erb
@@ -23,8 +23,4 @@
 
   <%= render 'bottom_description' %>
 
-  <div class='text-center find-more-div'>
-    Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
-  </div>
 </div>

--- a/app/views/home/_introduction.html.erb
+++ b/app/views/home/_introduction.html.erb
@@ -26,11 +26,6 @@
     <i>We DO NOT collect personal data. We do ask for your location to map internet speeds across America.</i>
   </p>
 
-  <div class='text-center find-more-div'>
-    Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
-  </div>
-
   <div class='row'>
     <div class='col-lg-7 col-xs-11 col-sm-9 col-centered'>
       <%= render partial: 'shared/partners', locals: {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,6 +58,7 @@
     <div class='yield-container'>
       <%= yield %>
     </div>
+    <%= render "shared/footer" %>
     <%= hidden_field_tag 'rails_env_constant', Rails.env, id: 'rails_env_constant' %>
   </div>
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,4 @@
+<div class='text-center find-more-div'>
+This website is an open source project which is always open to new contributors. To join in, visit
+<%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<div class='text-center find-more-div'>
-This website is an open source project which is always open to new contributors. To join in, visit
-<%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
+<div class='text-center find-more-div' style="background-color: white; padding-bottom: 1em">
+This website is an open source project which is always open to new contributors. To join in, 
+<%= link_to 'visit us on GitHub.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
 </div>

--- a/app/views/submissions/_about_speedup.html.erb
+++ b/app/views/submissions/_about_speedup.html.erb
@@ -19,9 +19,4 @@
   <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12 text-center export-data-div'>
     <%= link_to 'Export Data', export_csv_submissions_path, method: :post, class: 'btn btn-lg btn-primary export-btn' %>
   </div>
-
-  <div class='text-center find-more-div'>
-    Questions about speedupamerica.com? Find more information
-    <%= link_to 'here.', 'https://github.com/Hack4Eugene/SpeedUpAmerica', target: '_blank', rel: 'noopener' %>
-</div>
 </div>


### PR DESCRIPTION
Removed the following text from its current location on the homepage:
> Questions about speedupamerica.com? Find more information here.

Added the following text at the bottom of the page as a footer so that it's on every page:
> This website is an open source project which is always open to new contributors. To join in, visit SpeedUpAmerica on GitHub.

Per: https://github.com/Hack4Eugene/SpeedUpAmerica/issues/250