### PR TITLE
Add "Include M-Lab data" filter to map filters

### DIFF
--- a/app/assets/javascripts/mapboxgl.coffee
+++ b/app/assets/javascripts/mapboxgl.coffee
@@ -68,6 +68,7 @@ clearMap = (map) ->
       map.removeSource(layer.source)
 
 addLayer = (map, group_by, data, test_type) ->
+  console.log('addLayer', data)
   layer = layers[group_by]
   if layer == undefined
     throw new Error('unknown layer: ' + group_by)
@@ -147,9 +148,10 @@ addLayer = (map, group_by, data, test_type) ->
       .addTo(map)
   )
 
-window.set_mapbox_groupby = (map, provider, group_by, test_type, label) ->
+window.set_mapbox_groupby = (map, provider, group_by, test_type, is_from_mlab, label) ->
   loader = get_map_loader(map)
   loader.removeClass('hide')
+  console.log('set_mapbox_groupby', is_from_mlab)
 
   clearMap(map)
 
@@ -161,6 +163,7 @@ window.set_mapbox_groupby = (map, provider, group_by, test_type, label) ->
       provider: provider
       group_by: group_by
       test_type: test_type
+      is_from_mlab: is_from_mlab
     success: (data) ->
       addLayer(map, group_by, data.result, test_type)
 

--- a/app/assets/javascripts/mapboxgl.coffee
+++ b/app/assets/javascripts/mapboxgl.coffee
@@ -68,7 +68,6 @@ clearMap = (map) ->
       map.removeSource(layer.source)
 
 addLayer = (map, group_by, data, test_type) ->
-  console.log('addLayer', data)
   layer = layers[group_by]
   if layer == undefined
     throw new Error('unknown layer: ' + group_by)
@@ -148,10 +147,9 @@ addLayer = (map, group_by, data, test_type) ->
       .addTo(map)
   )
 
-window.set_mapbox_groupby = (map, provider, group_by, test_type, is_from_mlab, label) ->
+window.set_mapbox_groupby = (map, provider, group_by, test_type, include_from_mlab, label) ->
   loader = get_map_loader(map)
   loader.removeClass('hide')
-  console.log('set_mapbox_groupby', is_from_mlab)
 
   clearMap(map)
 
@@ -163,10 +161,9 @@ window.set_mapbox_groupby = (map, provider, group_by, test_type, is_from_mlab, l
       provider: provider
       group_by: group_by
       test_type: test_type
-      is_from_mlab: is_from_mlab
+      include_from_mlab: include_from_mlab
     success: (data) ->
       addLayer(map, group_by, data.result, test_type)
-
       loader.addClass('hide')
       disable_filters('map-filters', false)
     error: (request, statusText, errorText) ->

--- a/app/assets/javascripts/results.coffee
+++ b/app/assets/javascripts/results.coffee
@@ -50,16 +50,14 @@ apply_filters = (map) ->
     provider = $('#provider').val()
     group_by = $('#group_by').val()
     test_type = $('#test_type').val()
-    is_from_mlab = $('#is_from_mlab').is(":checked")
-    console.log("window.apply_filters/update_map")
-    console.log("  ", is_from_mlab)
+    include_from_mlab = $('#include_from_mlab').is(":checked")
 
     update_csv_link()
     disable_filters('map-filters', true)
 
     $('#all_results_map').removeClass('hide')
 
-    set_mapbox_groupby(map, provider, group_by, test_type, is_from_mlab)
+    set_mapbox_groupby(map, provider, group_by, test_type, include_from_mlab)
 
   $('#map-filters .filter').on 'change', ->
     update_all_option($(this))

--- a/app/assets/javascripts/results.coffee
+++ b/app/assets/javascripts/results.coffee
@@ -50,13 +50,16 @@ apply_filters = (map) ->
     provider = $('#provider').val()
     group_by = $('#group_by').val()
     test_type = $('#test_type').val()
+    is_from_mlab = $('#is_from_mlab').is(":checked")
+    console.log("window.apply_filters/update_map")
+    console.log("  ", is_from_mlab)
 
     update_csv_link()
     disable_filters('map-filters', true)
 
     $('#all_results_map').removeClass('hide')
 
-    set_mapbox_groupby(map, provider, group_by, test_type)
+    set_mapbox_groupby(map, provider, group_by, test_type, is_from_mlab)
 
   $('#map-filters .filter').on 'change', ->
     update_all_option($(this))

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -115,7 +115,7 @@
       }
     }
 
-    .group-by, .test-type, .provider {
+    .group-by, .test-type, .provider, .from-mlab {
       margin-bottom: 10px;
 
       button {
@@ -139,7 +139,7 @@
     float: left;
     width: 100%;
     padding-top: 20px;
-    p {
+    p,  .check-box-label {
       color: white;
     }
 
@@ -239,6 +239,9 @@
   margin-top: 20px;
 }
 
-input, textarea, select {
+// Including "input" causes checkboxes to not appear
+// https://stackoverflow.com/questions/16632955/checkboxes-not-displaying-chrome-work-in-other-browsers/23705615
+// input, textarea, select {
+textarea, select {
    -webkit-appearance: none !important;
 }

--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -239,9 +239,11 @@
   margin-top: 20px;
 }
 
-// Including "input" causes checkboxes to not appear
+// Including "input" in these selectors causes checkboxes to not appear on Chrome, unless we add the rule that's below it
 // https://stackoverflow.com/questions/16632955/checkboxes-not-displaying-chrome-work-in-other-browsers/23705615
-// input, textarea, select {
-textarea, select {
+input, textarea, select {
    -webkit-appearance: none !important;
+}
+input[type=checkbox] {
+  -webkit-appearance: checkbox !important;
 }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -368,12 +368,14 @@ class Submission < ActiveRecord::Base
   end
 
   def self.calculate_speed_data(params, providers, start_date, end_date, date_ranges)
+
     submissions = self.valid_test
     submissions = submissions.with_date_range(start_date, end_date)  if date_ranges.present?
     submissions = submissions.with_test_type(params[:test_type]) if params[:test_type].present?
     submissions = submissions.with_zip_code(params[:zip_code])   if params[:zip_code].present? && params[:zip_code].any?
     submissions = submissions.with_census_code(params[:census_code]) if params[:census_code].present? && params[:census_code].any?
     submissions = submissions.where(provider: providers)
+    # submissions = submissions.where(from_mlab: 1)
 
     test_type = params[:test_type]
     categories = date_ranges.collect { |range| range[:name] }

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -138,7 +138,7 @@ class Submission < ActiveRecord::Base
       stats = calculate_tileset_groupby(params, providers)
     else
       from_cache = true
-      stats = cached_tileset_groupby(params[:group_by], params[:test_type])
+      stats = cached_tileset_groupby(params[:group_by], params[:test_type], params[:include_from_mlab])
     end
 
     {
@@ -171,7 +171,8 @@ class Submission < ActiveRecord::Base
     stats
   end
 
-  def self.cached_tileset_groupby(group_by, test_type)
+  def self.cached_tileset_groupby(group_by, test_type, include_from_mlab)
+
     # Deal with census tract being poorly named in the rest of the code base
     if group_by == 'census_code'
       group_by = 'census_tract'
@@ -186,20 +187,38 @@ class Submission < ActiveRecord::Base
         'fillOpacity': 0.6,
       }
 
-      if test_type == 'download'
-        next if stats.download_count == 0
+      if include_from_mlab == "true"
+        if test_type == 'download'
+          next if stats.download_count == 0
 
-        result[:all_avg] = stats.download_avg
-        result[:all_median] = stats.download_median
-        result[:all_fast] = stats.download_max
-        result[:all_count] = stats.download_count
+          result[:all_avg] = stats.download_avg
+          result[:all_median] = stats.download_median
+          result[:all_fast] = stats.download_max
+          result[:all_count] = stats.download_count
+        else
+          next if stats.upload_count == 0
+
+          result[:all_avg] = stats.upload_avg
+          result[:all_median] = stats.upload_median
+          result[:all_fast] = stats.upload_max
+          result[:all_count] = stats.upload_count
+        end
       else
-        next if stats.upload_count == 0
+        if test_type == 'download'
+          next if stats.download_count == 0
 
-        result[:all_avg] = stats.upload_avg
-        result[:all_median] = stats.upload_median
-        result[:all_fast] = stats.upload_max
-        result[:all_count] = stats.upload_count
+          result[:all_avg] = stats.download_sua_avg
+          result[:all_median] = stats.download_sua_median
+          result[:all_fast] = stats.download_sua_max
+          result[:all_count] = stats.download_sua_count
+        else
+          next if stats.upload_count == 0
+
+          result[:all_avg] = stats.upload_sua_avg
+          result[:all_median] = stats.upload_sua_median
+          result[:all_fast] = stats.upload_sua_max
+          result[:all_count] = stats.upload_sua_count
+        end
       end
 
       result[:color] = set_color(result[:all_median])
@@ -368,14 +387,12 @@ class Submission < ActiveRecord::Base
   end
 
   def self.calculate_speed_data(params, providers, start_date, end_date, date_ranges)
-
     submissions = self.valid_test
     submissions = submissions.with_date_range(start_date, end_date)  if date_ranges.present?
     submissions = submissions.with_test_type(params[:test_type]) if params[:test_type].present?
     submissions = submissions.with_zip_code(params[:zip_code])   if params[:zip_code].present? && params[:zip_code].any?
     submissions = submissions.with_census_code(params[:census_code]) if params[:census_code].present? && params[:census_code].any?
     submissions = submissions.where(provider: providers)
-    # submissions = submissions.where(from_mlab: 1)
 
     test_type = params[:test_type]
     categories = date_ranges.collect { |range| range[:name] }

--- a/app/views/submissions/_filters.html.erb
+++ b/app/views/submissions/_filters.html.erb
@@ -54,10 +54,10 @@
     <div class='row'>
       <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12'>
         <div class='from-mlab'>
-          <span class='check-box-label'>
+          <label class='check-box-label' for='include_from_mlab' style="font-weight: normal;">
             <%= check_box_tag :include_from_mlab, "include_from_mlab", true, { disabled: true, class: 'filter' }  %>
             Include M-Lab data
-          <span>
+          </label>
         </div>
       </div>
     </div>

--- a/app/views/submissions/_filters.html.erb
+++ b/app/views/submissions/_filters.html.erb
@@ -55,7 +55,7 @@
       <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12'>
         <div class='from-mlab'>
           <span class='check-box-label'>
-            <%= check_box_tag :is_from_mlab, "1", true  %>
+            <%= check_box_tag :is_from_mlab, "is_from_mlab", true, { disabled: true, class: 'filter' }  %>
             Include M-Lab data
           <span>
         </div>

--- a/app/views/submissions/_filters.html.erb
+++ b/app/views/submissions/_filters.html.erb
@@ -55,7 +55,7 @@
       <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12'>
         <div class='from-mlab'>
           <span class='check-box-label'>
-            <%= check_box_tag :is_from_mlab, "is_from_mlab", true, { disabled: true, class: 'filter' }  %>
+            <%= check_box_tag :include_from_mlab, "include_from_mlab", true, { disabled: true, class: 'filter' }  %>
             Include M-Lab data
           <span>
         </div>

--- a/app/views/submissions/_filters.html.erb
+++ b/app/views/submissions/_filters.html.erb
@@ -51,5 +51,16 @@
       </div>
     </div>
 
+    <div class='row'>
+      <div class='col-xs-12 col-sm-12 col-md-12 col-lg-12'>
+        <div class='from-mlab'>
+          <span class='check-box-label'>
+            <%= check_box_tag :is_from_mlab, "1", true  %>
+            Include M-Lab data
+          <span>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>


### PR DESCRIPTION
Feature added as proposed in [thisissue](https://github.com/Hack4Eugene/SpeedUpAmerica/issues/224). 

When not including mlab data, uses _sua_ columns from stats_caches (e.g. `upload_sua_avg` instead of `upload_sua_avg`). 