### PR TITLE
Changed the Zendesk widget key -- no longer get 404

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
   </script>
 
   <!-- Start of speedupamerica Zendesk Widget script -->
-  <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=a6c92328-7d1a-41d6-892a-c9cf0b2034a0"> </script>
+  <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=c0957b4c-a84a-43de-9ce3-965ad066e2ff"> </script>
   <!-- End of speedupamerica Zendesk Widget script -->
 
 </head>


### PR DESCRIPTION
Addresses [this issue](https://github.com/Hack4Eugene/SpeedUpAmerica/issues/272), using new key provided by @mattsayre. 