### PR TITLE
Revert 'docker login' command

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,15 +2,13 @@ version: 0.2
 env:
   parameter-store:
       SUA_GEOLITE_ACCESS_KEY: SUA_GEOLITE_ACCESS_KEY
-      DOCKER_USERNAME: DOCKER_USERNAME
-      DOCKER_PASS: DOCKER_PASS
 phases:
   pre_build:
     commands:
       - echo Logging in to Amazon ECR...
       - aws --version
       - REPOSITORY_URI=238241637211.dkr.ecr.us-west-2.amazonaws.com/speedupamerica
-      - docker login --username $DOCKER_USERNAME -p $DOCKER_PASS $REPOSITORY_URI
+      - aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $REPOSITORY_URI
       - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:


### PR DESCRIPTION
Using the new Docker credentials does validate with AWS ECR, likely because ECR is a private repository.
In this PR, I'm reverting it back to what it was previously before this change.

```
[Container] 2022/04/15 17:12:24 Running command docker login --username $DOCKER_USERNAME -p $DOCKER_PASS $REPOSITORY_URI
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Error response from daemon: login attempt to https://238241637211.dkr.ecr.us-west-2.amazonaws.com/v2/ failed with status: 401 Unauthorized
```