### PR TITLE
iframe page for embedding in 3rd party websites #283

### DIFF
--- a/app/assets/region-javascripts/region.coffee
+++ b/app/assets/region-javascripts/region.coffee
@@ -159,50 +159,65 @@ region_take_the_test = ->
 # 1st box clicked
   $(".checkboxes-container input[name='region_submission[access]']").on 'change', ->
 
-
-    #$('#location_button').prop('disabled', false)
-    #if $("#location_success").prop('value') == 'false'
-      #$('#test-speed-btn').prop('disabled', true)
-      #$('#test-speed-btn').addClass('button-disabled')
+    $('#agree-div').removeClass('hide')
     $(".checkboxes-container input[name='region_submission[access]']").each ->
       $(this).prop('checked', false)
     $(this).prop('checked', true)
+    $('#agree').prop('checked', false)
+    $('#address-div').addClass('hide')
+    $('#addresswithinternet').addClass('hide')
+    $('#addresswithoutinternet').addClass('hide')
+    $('#price-div').addClass('hide')
+    $('#connectedornot-div').addClass('hide')
+    $('#testbutton-div').addClass('hide')
+
+
 
 
 # 1st box  choice 1 checked - HAVE ACCESS
-    if $('#access_have').prop('checked')
-      $('#access_donothave').prop('checked',false)
-      #$('#connected-with').removeClass('hide')
-      #$('#connectedornot-div').removeClass('hide')
-      $('#connectedornot-div').addClass('hide')
-      $('#price-div').removeClass('hide')
-      $('#address-div').removeClass('hide')
-      $('#nointernet').addClass('hide')
-      $('#addresswithinternet').removeClass('hide')
-      $('#addresswithoutinternet').addClass('hide')
-      $('#test-speed-btn').prop('innerHTML', 'Test My Speed')
-      $('#access-div').addClass('shrink') #shrink the first div
-      $('#price-text-notconnected').addClass('hide')
-      $('#price-text-connected').removeClass('hide')
-      $(".checkboxes-container input[name='region_submission[whynoaccess]']").each ->
-        $(this).prop('checked', false)
-				window.scrollBy(0,150)
+
+  $("#agree").on 'change', ->
+    if $('#agree').prop('checked')
+      if $('#access_have').prop('checked')
+        $('#access_donothave').prop('checked',false)
+        #$('#connected-with').removeClass('hide')
+        #$('#connectedornot-div').removeClass('hide')
+        $('#connectedornot-div').addClass('hide')
+        $('#price-div').removeClass('hide')
+        $('#address-div').removeClass('hide')
+        $('#nointernet').addClass('hide')
+        $('#addresswithinternet').removeClass('hide')
+        $('#addresswithoutinternet').addClass('hide')
+        $('#test-speed-btn').prop('innerHTML', 'Test My Speed')
+        $('#access-div').addClass('shrink') #shrink the first div
+        $('#price-text-connected').removeClass('hide')
+        $(".checkboxes-container input[name='region_submission[whynoaccess]']").each ->
+          $(this).prop('checked', false)
+        window.scrollBy(0,150)
 
 # 1st box choice 2 checked - DO NOT HAVE ACCESS
-    if $('#access_donothave').prop('checked')
-      $('#access_have').prop('checked',false)
-      $('#price-div').addClass('hide')
-      $('#connectedornot-div').removeClass('hide')
+      if $('#access_donothave').prop('checked')
+        $('#access_have').prop('checked',false)
+        $('#price-div').addClass('hide')
+        $('#connectedornot-div').removeClass('hide')
+        $('#address-div').addClass('hide')
+        $('#nointernet').removeClass('hide')
+        $('#connected-with').addClass('hide')
+        $('#addresswithinternet').addClass('hide')
+        $('#addresswithoutinternet').removeClass('hide')
+        $('#test-speed-btn').prop('innerHTML', 'Submit')
+        $('#access-div').addClass('shrink') #shrink the first div
+        $('#price-text-connected').addClass('hide')
+        $('#price-text-notconnected').removeClass('hide')
+        window.scrollBy(0,150)
+
+    else
       $('#address-div').addClass('hide')
-      $('#nointernet').removeClass('hide')
-      $('#connected-with').addClass('hide')
       $('#addresswithinternet').addClass('hide')
-      $('#addresswithoutinternet').removeClass('hide')
-      $('#test-speed-btn').prop('innerHTML', 'Submit')
-      $('#access-div').addClass('shrink') #shrink the first div
-      $('#price-text-connected').addClass('hide')
-      $('#price-text-notconnected').removeClass('hide')
-				window.scrollBy(0,150)
+      $('#addresswithoutinternet').addClass('hide')
+      $('#price-div').addClass('hide')
+      $('#connectedornot-div').addClass('hide')
+      $('#testbutton-div').addClass('hide')
 
 #if $('#access_have').prop('checked', false) and $('#access_donothave').prop('checked', false)
           #$('#connectedornot-div').addClass('hide')
@@ -219,7 +234,7 @@ region_take_the_test = ->
 # 2nd box group 2 check - WHY NOT CONNECTED
   $(".checkboxes-container input[name='region_submission[whynoaccess]']").on 'change', ->
     
-      $('#price-div').removeClass('hide')
+      $('#price-div').addClass('hide')
       $('#address-div').removeClass('hide')
 
 

--- a/app/assets/region-stylesheets/region-theme-all.scss
+++ b/app/assets/region-stylesheets/region-theme-all.scss
@@ -64,7 +64,19 @@ $bg1: #FFFFFF;
 		margin: $margin1;
 }
 
-
+.region.#{$region} div#agree-div {
+    background:$bgcolor4;
+    display: block;
+    padding: $padding1;
+    text-align: left;
+		border-radius: $border-radius1;
+		border: $border1;
+    box-shadow: $box-shadow1;
+		font-size: $fontsize1;
+		max-width: 700px;
+		width:100%;
+		margin: $margin1;
+}
 
 .region.#{$region} #connectedornot-div{
     background:$bgcolor2;

--- a/app/assets/region-stylesheets/region-theme-california.scss
+++ b/app/assets/region-stylesheets/region-theme-california.scss
@@ -64,7 +64,19 @@ $bg1: #FFFFFF;
 		margin: $margin1;
 }
 
-
+.region.#{$region} div#agree-div {
+    background:$bgcolor4;
+    display: block;
+    padding: $padding1;
+    text-align: left;
+		border-radius: $border-radius1;
+		border: $border1;
+    box-shadow: $box-shadow1;
+		font-size: $fontsize1;
+		max-width: 700px;
+		width:100%;
+		margin: $margin1;
+}
 
 .region.#{$region} #connectedornot-div{
     background:$bgcolor2;

--- a/app/assets/region-stylesheets/region-theme-oregon.scss
+++ b/app/assets/region-stylesheets/region-theme-oregon.scss
@@ -75,7 +75,19 @@ $bg1: url(https://upload.wikimedia.org/wikipedia/commons/c/cd/Central_Oregon_lan
 		margin: $margin1;
 }
 
-
+.region.#{$region} div#agree-div {
+    background:$bgcolor4;
+    display: block;
+    padding: $padding1;
+    text-align: left;
+		border-radius: $border-radius1;
+		border: $border1;
+    box-shadow: $box-shadow1;
+		font-size: $fontsize1;
+		max-width: 700px;
+		width:100%;
+		margin: $margin1;
+}
 
 .region.#{$region} #connectedornot-div{
     background:$bgcolor2;

--- a/app/assets/region-stylesheets/region-theme-washington.scss
+++ b/app/assets/region-stylesheets/region-theme-washington.scss
@@ -65,7 +65,19 @@ $bg1: #FFFFFF;
 		margin: $margin1;
 }
 
-
+.region.#{$region} div#agree-div {
+    background:$bgcolor4;
+    display: block;
+    padding: $padding1;
+    text-align: left;
+		border-radius: $border-radius1;
+		border: $border1;
+    box-shadow: $box-shadow1;
+		font-size: $fontsize1;
+		max-width: 700px;
+		width:100%;
+		margin: $margin1;
+}
 
 .region.#{$region} #connectedornot-div{
     background:$bgcolor2;

--- a/app/assets/region-stylesheets/region.css.scss
+++ b/app/assets/region-stylesheets/region.css.scss
@@ -95,7 +95,19 @@ $bg1: url(https://upload.wikimedia.org/wikipedia/commons/c/cd/Central_Oregon_lan
 		margin: $margin1;
 }
 
-
+.region div#agree-div {
+    background:$bgcolor4;
+    display: block;
+    padding: $padding1;
+    text-align: left;
+		border-radius: $border-radius1;
+		border: $border1;
+    box-shadow: $box-shadow1;
+		font-size: $fontsize1;
+		max-width: 700px;
+		width:100%;
+		margin: $margin1;
+}
 
 .region #connectedornot-div{
     background:$bgcolor2;

--- a/app/controllers/region_controller.rb
+++ b/app/controllers/region_controller.rb
@@ -5,6 +5,13 @@ class RegionController < ApplicationController
   def index
     @region_submission = RegionSubmission.new
 	@regionname = params[:regionname.downcase]
+
+	if (:regionname.downcase == 'oregon') 
+		@disclaimerlink = 'I agree to the <a href="https://www.measurementlab.net/privacy/" target="_blank" >data policy</a> and have read the <a href="https://test.fasterinternetoregon.org/disclaimer/"  target="_blank">disclaimer</a>'.html_safe
+	else
+		@disclaimerlink = 'I agree to the <a href="https://www.measurementlab.net/privacy/" target="_blank" >data policy</a> and have read the <a href="https://test.fasterinternetoregon.org/disclaimer/"  target="_blank">disclaimer</a>'.html_safe
+	end
+
   end
 
  

--- a/app/views/region/_form_step_0.html.erb
+++ b/app/views/region/_form_step_0.html.erb
@@ -20,11 +20,15 @@
       <%= f.check_box :access, { id: 'access_donothave', data: { target: '#form-step-1' } }, 'No access', false %>
       <%= label_tag :access_donothave, "I do NOT have internet access at my home".html_safe %>
     </div>
-
-	<span class='block-element' id="datapolicy">
-	    <p>By entering your information you agree to the <a href="/faq" target="_blank">data policy</a>. </p>
-	</span>
   </div>
+
+
+  <div class='checkboxes-container hide' id="agree-div">
+    <div class='checkbox checkbox-info'>
+		<%= check_box_tag(:agree) %>
+		<%= label_tag(:agree, @disclaimerlink) %>
+    </div>
+   </div>
 
 <% # STEP 2 HOW CONNECTED  OR WHY NOT CONNECTION  %>
   <div id="connectedornot-div" class="checkboxes-container hide">
@@ -72,13 +76,11 @@
 <% # STEP 3 PRICE  %>
 	<div id="price-div" class="hide">
 		<%= f.label :monthly_price, class: 'col-md-6' do %>
-          <p class='bold'>
+			<p class='bold'>
 		  
-		  <span id="price-text-connected">What is the estimated price you pay per month (optional)<br></span>
+			<span id="price-text-connected">What is the estimated price you pay per month (optional)<br></span>
 
-		  <span id="price-text-notconnected" class="hide">What is the estimated price you would pay per month for internet (optional)<br></span>
-
-          <span rel='tooltip' class='glyphicon glyphicon-info-sign info-color' title='By providing your monthly internet cost, we help determine if you are getting the internet speed and value you should be expecting.'></span></p>
+			</p>
         <% end %>
 
         <div class='col-md-4 restricted-field text-left'>


### PR DESCRIPTION
*Add second required checkbox on question 1 (have/have not internet). This will replace the passive agreement and associated language which is currently "By entering your information you agree to the data policy." NEW language next to new checkbox "I agree to the data policy https://www.measurementlab.net/privacy/ and have read the disclaimer <disclaimer site https://test.fasterinternetoregon.org/disclaimer/)>.

*Remove entirely the price I would pay question, under the click path for "i don't have internet".

*Remove the informational "i" in "What is the estimated price..." question, under the click path of "I have internet access at my home".